### PR TITLE
Add status support

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -24,6 +24,9 @@ class Pool implements ArrayAccess
     /** @var \Spatie\Async\ParallelProcess[] */
     protected $failed = [];
 
+    /** @var \Spatie\Async\ParallelProcess[]  */
+    protected $timeouts = [];
+
     protected $results = [];
 
     public function __construct()
@@ -157,7 +160,7 @@ class Pool implements ArrayAccess
 
         unset($this->inProgress[$process->getPid()]);
 
-        $this->failed[$process->getPid()] = $process;
+        $this->timeouts[$process->getPid()] = $process;
 
         $this->notify();
     }
@@ -209,6 +212,14 @@ class Pool implements ArrayAccess
     public function getFailed(): array
     {
         return $this->failed;
+    }
+
+    /**
+     * @return \Spatie\Async\ParallelProcess[]
+     */
+    public function getTimeouts(): array
+    {
+        return $this->timeouts;
     }
 
     protected function registerListener()

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -29,9 +29,13 @@ class Pool implements ArrayAccess
 
     protected $results = [];
 
+    protected $status;
+
     public function __construct()
     {
         $this->registerListener();
+
+        $this->status = new PoolStatus($this);
     }
 
     /**
@@ -220,6 +224,11 @@ class Pool implements ArrayAccess
     public function getTimeouts(): array
     {
         return $this->timeouts;
+    }
+
+    public function status(): PoolStatus
+    {
+        return $this->status;
     }
 
     protected function registerListener()

--- a/src/PoolDebugger.php
+++ b/src/PoolDebugger.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\Async;
+
+use Spatie\Async\Output\SerializableException;
+
+class PoolDebugger
+{
+    public static function statusForPool(Pool $pool): string
+    {
+        return self::summaryForPool($pool) . "\n"
+            . self::statusForFailed($pool);
+    }
+
+    public static function summaryForPool(Pool $pool): string
+    {
+        $finished = $pool->getFinished();
+        $failed = $pool->getFailed();
+        $timeouts = $pool->getTimeouts();
+
+        return 'finished: ' . count($finished)
+            . ' - failed: ' . count($failed)
+            . ' - timeouts: ' . count($timeouts);
+    }
+
+    public static function statusForFailed(Pool $pool): string
+    {
+        $failed = $pool->getFailed();
+
+        $status = "\nFailed status:\n\n";
+
+        foreach ($failed as $process) {
+            $output = $process->getErrorOutput();
+
+            if ($output instanceof SerializableException) {
+                $output = get_class($output->asThrowable()) . ' ' . $output->asThrowable()->getMessage();
+            }
+
+            $status .= "{$process->getId()} failed with {$output}\n\n";
+        }
+
+        return $status;
+    }
+}

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -23,7 +23,7 @@ class PoolStatus
 
     protected function lines(string ...$lines): string
     {
-        return implode("\n", $lines);
+        return implode(PHP_EOL, $lines);
     }
 
     protected function summaryToString(): string
@@ -39,20 +39,14 @@ class PoolStatus
 
     protected function failedToString(): string
     {
-        $failed = $this->pool->getFailed();
-
-        $status = '';
-
-        foreach ($failed as $process) {
+        return (string) array_reduce($this->pool->getFailed(), function ($currentStatus, ParallelProcess $process) {
             $output = $process->getErrorOutput();
 
             if ($output instanceof SerializableException) {
                 $output = get_class($output->asThrowable()).': '.$output->asThrowable()->getMessage();
             }
 
-            $status = $this->lines($status, "{$process->getPid()} failed with {$output}");
-        }
-
-        return $status;
+            return $this->lines((string) $currentStatus, "{$process->getPid()} failed with {$output}");
+        });
     }
 }

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -34,7 +34,7 @@ class PoolStatus
 
         return 'finished: '.count($finished)
             .' - failed: '.count($failed)
-            .' - timeouts: '.count($timeouts);
+            .' - timeout: '.count($timeouts);
     }
 
     protected function failedToString(): string

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -4,28 +4,43 @@ namespace Spatie\Async;
 
 use Spatie\Async\Output\SerializableException;
 
-class PoolDebugger
+class PoolStatus
 {
-    public static function statusForPool(Pool $pool): string
+    protected $pool;
+
+    public function __construct(Pool $pool)
     {
-        return self::summaryForPool($pool) . "\n"
-            . self::statusForFailed($pool);
+        $this->pool = $pool;
     }
 
-    public static function summaryForPool(Pool $pool): string
+    public function __toString(): string
     {
-        $finished = $pool->getFinished();
-        $failed = $pool->getFailed();
-        $timeouts = $pool->getTimeouts();
+        return $this->lines(
+            $this->summaryToString(),
+            $this->failedToString()
+        );
+    }
+
+    protected function lines(string ...$lines): string
+    {
+        return implode("\n", $lines);
+    }
+
+    protected function summaryToString(): string
+    {
+        $finished = $this->pool->getFinished();
+        $failed = $this->pool->getFailed();
+        $timeouts = $this->pool->getTimeouts();
 
         return 'finished: ' . count($finished)
             . ' - failed: ' . count($failed)
             . ' - timeouts: ' . count($timeouts);
     }
 
-    public static function statusForFailed(Pool $pool): string
+    protected function failedToString(): string
     {
-        $failed = $pool->getFailed();
+
+        $failed = $this->pool->getFailed();
 
         $status = "\nFailed status:\n\n";
 

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -39,19 +39,18 @@ class PoolStatus
 
     protected function failedToString(): string
     {
-
         $failed = $this->pool->getFailed();
 
-        $status = "\nFailed status:\n\n";
+        $status = '';
 
         foreach ($failed as $process) {
             $output = $process->getErrorOutput();
 
             if ($output instanceof SerializableException) {
-                $output = get_class($output->asThrowable()) . ' ' . $output->asThrowable()->getMessage();
+                $output = get_class($output->asThrowable()) . ': ' . $output->asThrowable()->getMessage();
             }
 
-            $status .= "{$process->getId()} failed with {$output}\n\n";
+            $status = $this->lines($status, "{$process->getPid()} failed with {$output}");
         }
 
         return $status;

--- a/tests/PoolStatusTest.php
+++ b/tests/PoolStatusTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\Async;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Spatie\Async\Tests\MyTask;
+
+class PoolStatusTest extends TestCase
+{
+    /** @test */
+    public function it_can_show_a_textual_status()
+    {
+        $pool = Pool::create();
+
+        $pool->add(new MyTask());
+
+        $this->assertContains('finished: 0', (string) $pool->status());
+
+        await($pool);
+
+        $this->assertContains('finished: 1', (string) $pool->status());
+    }
+
+    /** @test */
+    public function it_can_show_a_textual_failed_status()
+    {
+        $pool = Pool::create();
+
+        foreach (range(1, 5) as $i) {
+            $pool->add(function () {
+                throw new Exception('Test');
+            })->catch(function () {
+                // Do nothing
+            });
+        }
+
+        $pool->wait();
+
+        $this->assertContains('finished: 0', (string) $pool->status());
+        $this->assertContains('failed: 5', (string) $pool->status());
+        $this->assertContains('failed with Exception: Test', (string) $pool->status());
+    }
+
+    /** @test */
+    public function it_can_show_timeout_status()
+    {
+        $pool = Pool::create()->timeout(0);
+
+        foreach (range(1, 5) as $i) {
+            $pool->add(function () {
+                sleep(1000);
+            })->catch(function () {
+                // Do nothing
+            });
+        }
+
+        $pool->wait();
+
+        $this->assertContains('timeout: 5', (string) $pool->status());
+    }
+}

--- a/tests/PoolStatusTest.php
+++ b/tests/PoolStatusTest.php
@@ -50,8 +50,6 @@ class PoolStatusTest extends TestCase
         foreach (range(1, 5) as $i) {
             $pool->add(function () {
                 sleep(1000);
-            })->catch(function () {
-                // Do nothing
             });
         }
 

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -220,38 +220,4 @@ class PoolTest extends TestCase
     {
         $this->assertTrue(Pool::isSupported());
     }
-
-    /** @test */
-    public function it_can_show_a_textual_status()
-    {
-        $pool = Pool::create();
-
-        $pool->add(new MyTask());
-
-        $this->assertContains('finished: 0', (string) $pool->status());
-
-        await($pool);
-
-        $this->assertContains('finished: 1', (string) $pool->status());
-    }
-
-    /** @test */
-    public function it_can_show_a_textual_failed_status()
-    {
-        $pool = Pool::create();
-
-        foreach (range(1, 5) as $i) {
-            $pool->add(function () {
-                throw new Exception('Test');
-            })->catch(function () {
-                // Do nothing
-            });
-        }
-
-        $pool->wait();
-
-        $this->assertContains('finished: 0', (string) $pool->status());
-        $this->assertContains('failed: 5', (string) $pool->status());
-        $this->assertContains('failed with Exception: Test', (string) $pool->status());
-    }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -39,7 +39,7 @@ class PoolTest extends TestCase
 
         $executionTime = $endTime - $startTime;
 
-        $this->assertLessThan(0.2, $executionTime, "Execution time was {$executionTime}, expected less than 0.2.\n" . PoolDebugger::statusForPool($pool));
+        $this->assertLessThan(0.2, $executionTime, "Execution time was {$executionTime}, expected less than 0.2.\n" . (string) $pool->status());
     }
 
     /** @test */
@@ -59,7 +59,7 @@ class PoolTest extends TestCase
 
         $pool->wait();
 
-        $this->assertEquals(10, $counter, PoolDebugger::statusForPool($pool));
+        $this->assertEquals(10, $counter, (string) $pool->status());
     }
 
     /** @test */
@@ -80,7 +80,7 @@ class PoolTest extends TestCase
 
         $pool->wait();
 
-        $this->assertEquals(5, $counter, PoolDebugger::statusForPool($pool));
+        $this->assertEquals(5, $counter, (string) $pool->status());
     }
 
     /** @test */
@@ -98,7 +98,7 @@ class PoolTest extends TestCase
 
         $pool->wait();
 
-        $this->assertCount(5, $pool->getFailed(), PoolDebugger::statusForPool($pool));
+        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
     }
 
     /** @test */
@@ -121,8 +121,8 @@ class PoolTest extends TestCase
 
         $executionTime = $endTime - $startTime;
 
-        $this->assertGreaterThanOrEqual(2, $executionTime, "Execution time was {$executionTime}, expected more than 2.\n" . PoolDebugger::statusForPool($pool));
-        $this->assertCount(3, $pool->getFinished(), PoolDebugger::statusForPool($pool));
+        $this->assertGreaterThanOrEqual(2, $executionTime, "Execution time was {$executionTime}, expected more than 2.\n" . (string) $pool->status());
+        $this->assertCount(3, $pool->getFinished(), (string) $pool->status());
     }
 
     /** @test */
@@ -144,7 +144,7 @@ class PoolTest extends TestCase
 
         await($pool);
 
-        $this->assertEquals(10, $counter, PoolDebugger::statusForPool($pool));
+        $this->assertEquals(10, $counter, (string) $pool->status());
     }
 
     /** @test */
@@ -219,5 +219,19 @@ class PoolTest extends TestCase
     public function it_can_check_for_asynchronous_support()
     {
         $this->assertTrue(Pool::isSupported());
+    }
+
+    /** @test */
+    public function it_can_show_a_textual_status()
+    {
+        $pool = Pool::create();
+
+        $pool->add(new MyTask());
+
+        $this->assertContains('finished: 0', (string) $pool->status());
+
+        await($pool);
+
+        $this->assertContains('finished: 1', (string) $pool->status());
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -39,7 +39,7 @@ class PoolTest extends TestCase
 
         $executionTime = $endTime - $startTime;
 
-        $this->assertLessThan(0.2, $executionTime, "Execution time was {$executionTime}, expected less than 0.2.");
+        $this->assertLessThan(0.2, $executionTime, "Execution time was {$executionTime}, expected less than 0.2.\n" . PoolDebugger::statusForPool($pool));
     }
 
     /** @test */
@@ -59,7 +59,7 @@ class PoolTest extends TestCase
 
         $pool->wait();
 
-        $this->assertEquals(10, $counter);
+        $this->assertEquals(10, $counter, PoolDebugger::statusForPool($pool));
     }
 
     /** @test */
@@ -80,7 +80,7 @@ class PoolTest extends TestCase
 
         $pool->wait();
 
-        $this->assertEquals(5, $counter);
+        $this->assertEquals(5, $counter, PoolDebugger::statusForPool($pool));
     }
 
     /** @test */
@@ -98,7 +98,7 @@ class PoolTest extends TestCase
 
         $pool->wait();
 
-        $this->assertCount(5, $pool->getFailed());
+        $this->assertCount(5, $pool->getFailed(), PoolDebugger::statusForPool($pool));
     }
 
     /** @test */
@@ -121,8 +121,8 @@ class PoolTest extends TestCase
 
         $executionTime = $endTime - $startTime;
 
-        $this->assertGreaterThanOrEqual(2, $executionTime, "Execution time was {$executionTime}, expected more than 2.");
-        $this->assertCount(3, $pool->getFinished());
+        $this->assertGreaterThanOrEqual(2, $executionTime, "Execution time was {$executionTime}, expected more than 2.\n" . PoolDebugger::statusForPool($pool));
+        $this->assertCount(3, $pool->getFinished(), PoolDebugger::statusForPool($pool));
     }
 
     /** @test */
@@ -144,7 +144,7 @@ class PoolTest extends TestCase
 
         await($pool);
 
-        $this->assertEquals(10, $counter);
+        $this->assertEquals(10, $counter, PoolDebugger::statusForPool($pool));
     }
 
     /** @test */

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -234,4 +234,24 @@ class PoolTest extends TestCase
 
         $this->assertContains('finished: 1', (string) $pool->status());
     }
+
+    /** @test */
+    public function it_can_show_a_textual_failed_status()
+    {
+        $pool = Pool::create();
+
+        foreach (range(1, 5) as $i) {
+            $pool->add(function () {
+                throw new Exception('Test');
+            })->catch(function () {
+                // Do nothing
+            });
+        }
+
+        $pool->wait();
+
+        $this->assertContains('finished: 0', (string) $pool->status());
+        $this->assertContains('failed: 5', (string) $pool->status());
+        $this->assertContains('failed with Exception: Test', (string) $pool->status());
+    }
 }


### PR DESCRIPTION
I've noticed the Travis builds failing from time to time. To be able to debug this, I need more information about the pool. This PR adds a class which is used to print out the status of the pool as a test failing message.

An example of a failing build: https://travis-ci.org/spatie/async/jobs/323771446 

Re-running builds fixes the tests, so it's not an easy to reproduce issue.

This debugger is a quick addition, but maybe can be improved upon in the future to be useful in real application too.