### PR TITLE
Add `Pool::isSupported`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $pool = Pool::create();
 foreach ($things as $thing) {
     $task = new MyTask($thing);
     
-    if (!Pool::isSupported()) {
+    if (! Pool::isSupported()) {
         $task->execute();
         
         continue;

--- a/README.md
+++ b/README.md
@@ -138,6 +138,30 @@ class MyTask extends Task
 $pool->add(new MyTask());
 ```
 
+### Check for platform support at runtime
+
+The `Pool` class has a static method `isSupported` you can call to check whether your platform is able to run asynchronous processes. You can use this check in combination with a `Task` to be able to easily run the same code synchronous or asynchronous.
+
+```php
+$pool = Pool::create();
+
+foreach ($things as $thing) {
+    $task = new MyTask($thing);
+    
+    if (!Pool::isSupported()) {
+        $task->execute();
+        
+        continue;
+    }
+
+    $pool->add($task);
+}
+
+if (Pool::isSupported()) {
+    $pool->wait();
+}
+``` 
+
 ## Behind the curtains
 
 When using this package, you're probably wondering what's happening underneath the surface.

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -39,6 +39,11 @@ class Pool implements ArrayAccess
         return new static();
     }
 
+    public static function isSupported(): bool
+    {
+        return function_exists('pcntl_async_signals') && function_exists('posix_kill');
+    }
+
     public function concurrency(int $concurrency): self
     {
         $this->concurrency = $concurrency;

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -12,6 +12,12 @@ class PoolTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
+
+        $supported = Pool::isSupported();
+
+        if (!$supported) {
+            $this->markTestSkipped('Extensions `posix` and `pcntl` not supported.');
+        }
     }
 
     /** @test */
@@ -207,5 +213,11 @@ class PoolTest extends TestCase
         $results = await($pool);
 
         $this->assertEquals(2, $results[0]);
+    }
+
+    /** @test */
+    public function it_can_check_for_asynchronous_support()
+    {
+        $this->assertTrue(Pool::isSupported());
     }
 }


### PR DESCRIPTION
As far as I am concerned, this is the last feature required for a working release. It allows users to check whether the correct functions are available for asynchronous processing at runtime.

This allows applications to fallback to synchronous processing.

In the future, we could also incorporate this check in the pool itself, which could execute processes synchronous as a fallback. That's not a requirement for a first release though.