### PR TITLE
Synchronous fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,29 +172,13 @@ $pool = Pool::create()
 ;
 ```
 
-### Asynchronous support at runtime
+### Synchronous fallback
 
-The `Pool` class has a static method `isSupported` you can call to check whether your platform is able to run asynchronous processes. You can use this check in combination with a `Task` to be able to easily run the same code synchronous or asynchronous.
+If the required extensions (`pctnl` and `posix`) are not installed in your current PHP runtime, the `Pool` will automatically fallback to synchronous execution of tasks.
 
-```php
-$pool = Pool::create();
+The `Pool` class has a static method `isSupported` you can call to check whether your platform is able to run asynchronous processes. 
 
-foreach ($things as $thing) {
-    $task = new MyTask($thing);
-    
-    if (! Pool::isSupported()) {
-        $task->execute();
-        
-        continue;
-    }
-
-    $pool->add($task);
-}
-
-if (Pool::isSupported()) {
-    $pool->wait();
-}
-``` 
+If you're using a `Task` to run processes, only the `execute` method of those tasks will be called when running in synchronous mode.
 
 ## Behind the curtains
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "larapack/dd": "^1.1",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "symfony/stopwatch": "^4.0"
     },
     "autoload": {
         "files": [

--- a/src/Output/ParallelError.php
+++ b/src/Output/ParallelError.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\Async;
+namespace Spatie\Async\Output;
 
 use Exception;
 

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -6,8 +6,8 @@ use ArrayAccess;
 use InvalidArgumentException;
 use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;
-use Spatie\Async\Process\SynchronousProcess;
 use Spatie\Async\Runtime\ParentRuntime;
+use Spatie\Async\Process\SynchronousProcess;
 
 class Pool implements ArrayAccess
 {
@@ -57,7 +57,7 @@ class Pool implements ArrayAccess
         return
             function_exists('pcntl_async_signals')
             && function_exists('posix_kill')
-            && !Pool::$forceSynchronous;
+            && ! self::$forceSynchronous;
     }
 
     public function concurrency(int $concurrency): self

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,6 +4,8 @@ namespace Spatie\Async;
 
 use ArrayAccess;
 use InvalidArgumentException;
+use Spatie\Async\Process\ParallelProcess;
+use Spatie\Async\Process\Runnable;
 use Spatie\Async\Runtime\ParentRuntime;
 
 class Pool implements ArrayAccess
@@ -13,19 +15,19 @@ class Pool implements ArrayAccess
     protected $timeout = 300;
     protected $sleepTime = 50000;
 
-    /** @var \Spatie\Async\ParallelProcess[] */
+    /** @var \Spatie\Async\Process\Runnable[] */
     protected $queue = [];
 
-    /** @var \Spatie\Async\ParallelProcess[] */
+    /** @var \Spatie\Async\Process\Runnable[] */
     protected $inProgress = [];
 
-    /** @var \Spatie\Async\ParallelProcess[] */
+    /** @var \Spatie\Async\Process\Runnable[] */
     protected $finished = [];
 
-    /** @var \Spatie\Async\ParallelProcess[] */
+    /** @var \Spatie\Async\Process\Runnable[] */
     protected $failed = [];
 
-    /** @var \Spatie\Async\ParallelProcess[] */
+    /** @var \Spatie\Async\Process\Runnable[] */
     protected $timeouts = [];
 
     protected $results = [];
@@ -96,18 +98,18 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @param \Spatie\Async\ParallelProcess|callable $process
+     * @param \Spatie\Async\Process\Runnable|callable $process
      *
-     * @return \Spatie\Async\ParallelProcess
+     * @return \Spatie\Async\Process\Runnable
      */
-    public function add($process): ParallelProcess
+    public function add($process): Runnable
     {
-        if (! is_callable($process) && ! $process instanceof ParallelProcess) {
+        if (! is_callable($process) && ! $process instanceof Runnable) {
             throw new InvalidArgumentException('The process passed to Pool::add should be callable.');
         }
 
-        if (! $process instanceof ParallelProcess) {
-            $process = ParentRuntime::createChildProcess($process);
+        if (! $process instanceof Runnable) {
+            $process = ParentRuntime::createProcess($process);
         }
 
         $this->putInQueue($process);
@@ -134,16 +136,18 @@ class Pool implements ArrayAccess
         return $this->results;
     }
 
-    public function putInQueue(ParallelProcess $process)
+    public function putInQueue(Runnable $process)
     {
         $this->queue[$process->getId()] = $process;
 
         $this->notify();
     }
 
-    public function putInProgress(ParallelProcess $process)
+    public function putInProgress(Runnable $process)
     {
-        $process->getProcess()->setTimeout($this->timeout);
+        if ($process instanceof ParallelProcess) {
+            $process->getProcess()->setTimeout($this->timeout);
+        }
 
         $process->start();
 
@@ -152,7 +156,7 @@ class Pool implements ArrayAccess
         $this->inProgress[$process->getPid()] = $process;
     }
 
-    public function markAsFinished(ParallelProcess $process)
+    public function markAsFinished(Runnable $process)
     {
         unset($this->inProgress[$process->getPid()]);
 
@@ -163,7 +167,7 @@ class Pool implements ArrayAccess
         $this->finished[$process->getPid()] = $process;
     }
 
-    public function markAsTimedOut(ParallelProcess $process)
+    public function markAsTimedOut(Runnable $process)
     {
         unset($this->inProgress[$process->getPid()]);
 
@@ -174,7 +178,7 @@ class Pool implements ArrayAccess
         $this->timeouts[$process->getPid()] = $process;
     }
 
-    public function markAsFailed(ParallelProcess $process)
+    public function markAsFailed(Runnable $process)
     {
         unset($this->inProgress[$process->getPid()]);
 
@@ -208,7 +212,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\ParallelProcess[]
+     * @return \Spatie\Async\Process\Runnable[]
      */
     public function getFinished(): array
     {
@@ -216,7 +220,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\ParallelProcess[]
+     * @return \Spatie\Async\Process\Runnable[]
      */
     public function getFailed(): array
     {
@@ -224,7 +228,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\ParallelProcess[]
+     * @return \Spatie\Async\Process\Runnable[]
      */
     public function getTimeouts(): array
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,9 +4,9 @@ namespace Spatie\Async;
 
 use ArrayAccess;
 use InvalidArgumentException;
-use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;
 use Spatie\Async\Runtime\ParentRuntime;
+use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\SynchronousProcess;
 
 class Pool implements ArrayAccess

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Async;
 
-use Spatie\Async\Output\SerializableException;
 use Spatie\Async\Process\ParallelProcess;
+use Spatie\Async\Output\SerializableException;
 
 class PoolStatus
 {

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -29,11 +29,14 @@ class PoolStatus
 
     protected function summaryToString(): string
     {
+        $queue = $this->pool->getQueue();
         $finished = $this->pool->getFinished();
         $failed = $this->pool->getFailed();
         $timeouts = $this->pool->getTimeouts();
 
-        return 'finished: '.count($finished)
+        return
+            'queue: '.count($queue)
+            .' - finished: '.count($finished)
             .' - failed: '.count($failed)
             .' - timeout: '.count($timeouts);
     }

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -3,6 +3,7 @@
 namespace Spatie\Async;
 
 use Spatie\Async\Output\SerializableException;
+use Spatie\Async\Process\ParallelProcess;
 
 class PoolStatus
 {

--- a/src/Process/ParallelProcess.php
+++ b/src/Process/ParallelProcess.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Async\Process;
 
-use Spatie\Async\Output\ParallelError;
 use Throwable;
+use Spatie\Async\Output\ParallelError;
 use Symfony\Component\Process\Process;
 use Spatie\Async\Output\SerializableException;
 

--- a/src/Process/ProcessCallbacks.php
+++ b/src/Process/ProcessCallbacks.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Spatie\Async\Process;
+
+trait ProcessCallbacks
+{
+    protected $successCallbacks = [];
+    protected $errorCallbacks = [];
+    protected $timeoutCallbacks = [];
+
+    public function then(callable $callback): self
+    {
+        $this->successCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function catch(callable $callback): self
+    {
+        $this->errorCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function timeout(callable $callback): self
+    {
+        $this->timeoutCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    public function triggerSuccess()
+    {
+        if ($this->getErrorOutput()) {
+            $this->triggerError();
+
+            return;
+        }
+
+        $output = $this->getOutput();
+
+        foreach ($this->successCallbacks as $callback) {
+            call_user_func_array($callback, [$output]);
+        }
+
+        return $output;
+    }
+
+    public function triggerError()
+    {
+        $exception = $this->resolveErrorOutput();
+
+        foreach ($this->errorCallbacks as $callback) {
+            call_user_func_array($callback, [$exception]);
+        }
+
+        if (! $this->errorCallbacks) {
+            throw $exception;
+        }
+    }
+
+    public function triggerTimeout()
+    {
+        foreach ($this->timeoutCallbacks as $callback) {
+            call_user_func_array($callback, []);
+        }
+    }
+}

--- a/src/Process/Runnable.php
+++ b/src/Process/Runnable.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Async\Process;
+
+interface Runnable
+{
+    public function getId(): int;
+
+    public function getPid(): ?int;
+
+    public function start();
+
+    public function then(callable $callback);
+
+    public function catch(callable $callback);
+
+    public function timeout(callable $callback);
+
+    public function stop();
+
+    public function getOutput();
+
+    public function getErrorOutput();
+
+    public function triggerSuccess();
+
+    public function triggerError();
+
+    public function triggerTimeout();
+
+    public function getCurrentExecutionTime(): float;
+}

--- a/src/Process/SynchronousProcess.php
+++ b/src/Process/SynchronousProcess.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\Async\Process;
 
-use Spatie\Async\Task;
 use Throwable;
+use Spatie\Async\Task;
 
 class SynchronousProcess implements Runnable
 {
@@ -55,7 +55,6 @@ class SynchronousProcess implements Runnable
 
     public function stop()
     {
-        return null;
     }
 
     public function getOutput()

--- a/src/Process/SynchronousProcess.php
+++ b/src/Process/SynchronousProcess.php
@@ -43,11 +43,9 @@ class SynchronousProcess implements Runnable
         try {
             $startTime = microtime(true);
 
-            if ($this->task instanceof Task) {
-                $this->output = $this->task->execute();
-            } else {
-                $this->output = call_user_func($this->task);
-            }
+            $this->output = $this->task instanceof Task
+                ? $this->task->execute()
+                : call_user_func($this->task);
 
             $this->executionTime = microtime(true) - $startTime;
         } catch (Throwable $throwable) {

--- a/src/Process/SynchronousProcess.php
+++ b/src/Process/SynchronousProcess.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Spatie\Async\Process;
+
+use Spatie\Async\Task;
+use Throwable;
+
+class SynchronousProcess implements Runnable
+{
+    protected $id;
+
+    protected $task;
+
+    protected $output;
+    protected $errorOutput;
+    protected $executionTime;
+
+    use ProcessCallbacks;
+
+    public function __construct(callable $task, int $id)
+    {
+        $this->id = $id;
+        $this->task = $task;
+    }
+
+    public static function create(callable $task, int $id): self
+    {
+        return new self($task, $id);
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getPid(): ?int
+    {
+        return $this->getId();
+    }
+
+    public function start()
+    {
+        try {
+            $startTime = microtime(true);
+
+            if ($this->task instanceof Task) {
+                $this->output = $this->task->execute();
+            } else {
+                $this->output = call_user_func($this->task);
+            }
+
+            $this->executionTime = $startTime - microtime(true);
+        } catch (Throwable $throwable) {
+            $this->errorOutput = $throwable;
+        }
+    }
+
+    public function stop()
+    {
+        return null;
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+
+    public function getErrorOutput()
+    {
+        return $this->errorOutput;
+    }
+
+    public function getCurrentExecutionTime(): float
+    {
+        return $this->executionTime;
+    }
+}

--- a/src/Process/SynchronousProcess.php
+++ b/src/Process/SynchronousProcess.php
@@ -49,7 +49,7 @@ class SynchronousProcess implements Runnable
                 $this->output = call_user_func($this->task);
             }
 
-            $this->executionTime = $startTime - microtime(true);
+            $this->executionTime = microtime(true) - $startTime;
         } catch (Throwable $throwable) {
             $this->errorOutput = $throwable;
         }

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -3,7 +3,9 @@
 namespace Spatie\Async\Runtime;
 
 use Closure;
-use Spatie\Async\ParallelProcess;
+use Spatie\Async\Pool;
+use Spatie\Async\Process\Runnable;
+use Spatie\Async\Process\SynchronousProcess;
 use function Opis\Closure\serialize;
 use Opis\Closure\SerializableClosure;
 use function Opis\Closure\unserialize;
@@ -48,12 +50,16 @@ class ParentRuntime
     /**
      * @param \Spatie\Async\Task|callable $task
      *
-     * @return \Spatie\Async\ParallelProcess
+     * @return \Spatie\Async\Process\Runnable
      */
-    public static function createChildProcess($task): ParallelProcess
+    public static function createProcess($task): Runnable
     {
         if (! self::$isInitialised) {
             self::init();
+        }
+
+        if (! Pool::isSupported()) {
+            return SynchronousProcess::create($task, self::getId());
         }
 
         $process = new Process(implode(' ', [

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -10,6 +10,7 @@ use function Opis\Closure\serialize;
 use Opis\Closure\SerializableClosure;
 use function Opis\Closure\unserialize;
 use Symfony\Component\Process\Process;
+use Spatie\Async\Process\ParallelProcess;
 
 class ParentRuntime
 {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,18 +1,18 @@
 <?php
 
 use Spatie\Async\Pool;
-use Spatie\Async\ParallelProcess;
+use Spatie\Async\Process\Runnable;
 use Spatie\Async\Runtime\ParentRuntime;
 
 if (! function_exists('async')) {
     /**
      * @param \Spatie\Async\Task|callable $task
      *
-     * @return \Spatie\Async\ParallelProcess
+     * @return \Spatie\Async\Process\ParallelProcess
      */
-    function async($task): ParallelProcess
+    function async($task): Runnable
     {
-        return ParentRuntime::createChildProcess($task);
+        return ParentRuntime::createProcess($task);
     }
 }
 

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -5,7 +5,7 @@ namespace Spatie\Async\Tests;
 use Error;
 use Spatie\Async\Pool;
 use PHPUnit\Framework\TestCase;
-use Spatie\Async\ParallelError;
+use Spatie\Async\Output\ParallelError;
 
 class ErrorHandlingTest extends TestCase
 {

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -3,13 +3,13 @@
 namespace Spatie\Async;
 
 use InvalidArgumentException;
-use Spatie\Async\Tests\InvokableClass;
-use Spatie\Async\Process\SynchronousProcess;
 use Spatie\Async\Tests\MyTask;
 use PHPUnit\Framework\TestCase;
 use Spatie\Async\Tests\MyClass;
+use Spatie\Async\Tests\InvokableClass;
 use Spatie\Async\Tests\NonInvokableClass;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Spatie\Async\Process\SynchronousProcess;
 
 class PoolTest extends TestCase
 {

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -46,7 +46,7 @@ class PoolTest extends TestCase
 
         $stopwatchResult = $this->stopwatch->stop('test');
 
-        $this->assertLessThan(200, $stopwatchResult->getDuration(), "Execution time was {$stopwatchResult->getDuration()}, expected less than 0.2.\n".(string) $pool->status());
+        $this->assertLessThan(400, $stopwatchResult->getDuration(), "Execution time was {$stopwatchResult->getDuration()}, expected less than 400.\n".(string) $pool->status());
     }
 
     /** @test */

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -248,7 +248,6 @@ class PoolTest extends TestCase
             });
         }
 
-
         $pool->wait();
 
         $stopwatchResult = $this->stopwatch->stop('test');


### PR DESCRIPTION
Not quite sure if this is the implementation I want to settle on, but I'd like your input @freekmurze 

What I definitely don't like is that `public static $forceSynchronous = false;` property. I can't come up with a better way to be able to change the outcome of `isSupported` for one test. 

Thinking about it, maybe setting an ENV variable would be good? I don't think mocking the class would work, would it? Because that static method is used in `ParentRuntime` to determine whether it should create synchronous or parellel processes.