### PR TITLE
Remove SerializableClosure security provider

### DIFF
--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -81,7 +81,10 @@ class ParentRuntime
     public static function encodeTask($task): string
     {
         if ($task instanceof Closure) {
+            $securityProvider = SerializableClosure::getSecurityProvider();
+            SerializableClosure::removeSecurityProvider();
             $task = new SerializableClosure($task);
+            SerializableClosure::addSecurityProvider($securityProvider);
         }
 
         return base64_encode(serialize($task));


### PR DESCRIPTION
If a secret key was set on the SerializableClosure then any future closure will be signed. This occurs in the Laravel framework. The child processes are not ran in Laravel thus not using the secret key that was set thus failing. This edit will temporarily remove the security provider, create an unsigned closure and set the provider back to original.