### PR TITLE
Bugfix handling exception in synchronous process

### DIFF
--- a/src/Process/ProcessCallbacks.php
+++ b/src/Process/ProcessCallbacks.php
@@ -68,6 +68,8 @@ trait ProcessCallbacks
         }
     }
 
+    abstract protected function resolveErrorOutput(): Throwable;
+
     public function triggerTimeout()
     {
         foreach ($this->timeoutCallbacks as $callback) {

--- a/src/Process/SynchronousProcess.php
+++ b/src/Process/SynchronousProcess.php
@@ -71,4 +71,9 @@ class SynchronousProcess implements Runnable
     {
         return $this->executionTime;
     }
+
+    protected function resolveErrorOutput(): Throwable
+    {
+        return $this->getErrorOutput();
+    }
 }

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -26,7 +26,7 @@ class ErrorHandlingTest extends TestCase
 
         $pool->wait();
 
-        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
+        $this->assertCount(5, $pool->getFailed(), (string)$pool->status());
     }
 
     /** @test */
@@ -63,7 +63,7 @@ class ErrorHandlingTest extends TestCase
         $this->assertEquals(5, $myExceptionCount);
         $this->assertEquals(0, $otherExceptionCount);
         $this->assertEquals(0, $exceptionCount);
-        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
+        $this->assertCount(5, $pool->getFailed(), (string)$pool->status());
     }
 
     /** @test */
@@ -138,5 +138,24 @@ class ErrorHandlingTest extends TestCase
         });
 
         $pool->wait();
+    }
+
+    /** @test */
+    public function it_can_handle_synchronous_exception()
+    {
+        Pool::$forceSynchronous = true;
+
+        $pool = Pool::create();
+
+        $pool->add(function () {
+            throw new MyException('test');
+        })->catch(function (MyException $e) {
+
+            $this->assertRegExp('/test/', $e->getMessage());
+        });
+
+        $pool->wait();
+
+        Pool::$forceSynchronous = false;
     }
 }

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -26,7 +26,7 @@ class ErrorHandlingTest extends TestCase
 
         $pool->wait();
 
-        $this->assertCount(5, $pool->getFailed(), (string)$pool->status());
+        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
     }
 
     /** @test */
@@ -63,7 +63,7 @@ class ErrorHandlingTest extends TestCase
         $this->assertEquals(5, $myExceptionCount);
         $this->assertEquals(0, $otherExceptionCount);
         $this->assertEquals(0, $exceptionCount);
-        $this->assertCount(5, $pool->getFailed(), (string)$pool->status());
+        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
     }
 
     /** @test */
@@ -150,7 +150,6 @@ class ErrorHandlingTest extends TestCase
         $pool->add(function () {
             throw new MyException('test');
         })->catch(function (MyException $e) {
-
             $this->assertRegExp('/test/', $e->getMessage());
         });
 


### PR DESCRIPTION
Add an abstract method `resolveErrorOutput` to `ProcessCallbacks` trait currently only `ParallelProcess` implement it. 