### PR TITLE
Add flush method to Pool.

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -59,7 +59,7 @@ class Pool implements ArrayAccess
         return
             function_exists('pcntl_async_signals')
             && function_exists('posix_kill')
-            && ! self::$forceSynchronous;
+            && !self::$forceSynchronous;
     }
 
     public function concurrency(int $concurrency): self
@@ -98,7 +98,7 @@ class Pool implements ArrayAccess
 
         $process = array_shift($this->queue);
 
-        if (! $process) {
+        if (!$process) {
             return;
         }
 
@@ -112,11 +112,11 @@ class Pool implements ArrayAccess
      */
     public function add($process): Runnable
     {
-        if (! is_callable($process) && ! $process instanceof Runnable) {
+        if (!is_callable($process) && !$process instanceof Runnable) {
             throw new InvalidArgumentException('The process passed to Pool::add should be callable.');
         }
 
-        if (! $process instanceof Runnable) {
+        if (!$process instanceof Runnable) {
             $process = ParentRuntime::createProcess($process);
         }
 
@@ -138,7 +138,7 @@ class Pool implements ArrayAccess
                 }
             }
 
-            if (! $this->inProgress) {
+            if (!$this->inProgress) {
                 break;
             }
 
@@ -272,6 +272,16 @@ class Pool implements ArrayAccess
         return $this->status;
     }
 
+    public function flush(): void
+    {
+        $this->results = [];
+        $this->failed = [];
+        $this->finished = [];
+        $this->queue = [];
+        $this->timeouts = [];
+        $this->inProgress = [];
+    }
+
     protected function registerListener()
     {
         pcntl_async_signals(true);
@@ -286,7 +296,7 @@ class Pool implements ArrayAccess
 
                 $process = $this->inProgress[$pid] ?? null;
 
-                if (! $process) {
+                if (!$process) {
                     continue;
                 }
 


### PR DESCRIPTION
Currently no ways to clear old results of the `Pool`. I think we should support it in case call multi `wait` to get result of processes but old result of previous block exist in it.