### PR TITLE
Fix for Symfony Process argument deprecation

### DIFF
--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -63,12 +63,12 @@ class ParentRuntime
             return SynchronousProcess::create($task, self::getId());
         }
 
-        $process = new Process(implode(' ', [
-            'exec php',
+        $process = new Process([
+            'php',
             self::$childProcessScript,
             self::$autoloader,
             self::encodeTask($task),
-        ]));
+        ]);
 
         return ParallelProcess::create($process, self::getId());
     }

--- a/tests/ChildRuntimeTest.php
+++ b/tests/ChildRuntimeTest.php
@@ -24,7 +24,7 @@ class ChildRuntimeTest extends TestCase
             'php',
             $bootstrap,
             $autoloader,
-            $serializedClosure
+            $serializedClosure,
         ]);
 
         $process->start();

--- a/tests/ChildRuntimeTest.php
+++ b/tests/ChildRuntimeTest.php
@@ -20,7 +20,12 @@ class ChildRuntimeTest extends TestCase
             echo 'child';
         })));
 
-        $process = new Process("php {$bootstrap} {$autoloader} {$serializedClosure}");
+        $process = new Process([
+            'php',
+            $bootstrap,
+            $autoloader,
+            $serializedClosure
+        ]);
 
         $process->start();
 


### PR DESCRIPTION
Solves https://github.com/spatie/async/issues/75

Unittests passing with Symfony Process 3.3 and 4.3, so no dependency bumps should be necessary.

Symfony takes care of prepending `exec` when passing in an array.