### PR TITLE
refactor default max output length to be modified by the user

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -107,17 +107,18 @@ class Pool implements ArrayAccess
 
     /**
      * @param \Spatie\Async\Process\Runnable|callable $process
+     * @param int|null $outputLength
      *
      * @return \Spatie\Async\Process\Runnable
      */
-    public function add($process): Runnable
+    public function add($process, ?int $outputLength = null): Runnable
     {
         if (! is_callable($process) && ! $process instanceof Runnable) {
             throw new InvalidArgumentException('The process passed to Pool::add should be callable.');
         }
 
         if (! $process instanceof Runnable) {
-            $process = ParentRuntime::createProcess($process);
+            $process = ParentRuntime::createProcess($process, $outputLength);
         }
 
         $this->putInQueue($process);

--- a/src/Runtime/ChildRuntime.php
+++ b/src/Runtime/ChildRuntime.php
@@ -5,6 +5,7 @@ use Spatie\Async\Runtime\ParentRuntime;
 try {
     $autoloader = $argv[1] ?? null;
     $serializedClosure = $argv[2] ?? null;
+    $outputLength = $argv[3] ?? (1024 * 10);
 
     if (! $autoloader) {
         throw new InvalidArgumentException('No autoloader provided in child process.');
@@ -25,8 +26,6 @@ try {
     $output = call_user_func($task);
 
     $serializedOutput = base64_encode(serialize($output));
-
-    $outputLength = 1024 * 10;
 
     if (strlen($serializedOutput) > $outputLength) {
         throw \Spatie\Async\Output\ParallelError::outputTooLarge($outputLength);

--- a/src/Runtime/ChildRuntime.php
+++ b/src/Runtime/ChildRuntime.php
@@ -5,7 +5,7 @@ use Spatie\Async\Runtime\ParentRuntime;
 try {
     $autoloader = $argv[1] ?? null;
     $serializedClosure = $argv[2] ?? null;
-    $outputLength = $argv[3] ?? (1024 * 10);
+    $outputLength = $argv[3] ? intval($argv[3]) : (1024 * 10);
 
     if (! $autoloader) {
         throw new InvalidArgumentException('No autoloader provided in child process.');

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -69,7 +69,7 @@ class ParentRuntime
             self::$childProcessScript,
             self::$autoloader,
             self::encodeTask($task),
-            $outputLength
+            $outputLength,
         ]);
 
         return ParallelProcess::create($process, self::getId());

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -50,10 +50,11 @@ class ParentRuntime
 
     /**
      * @param \Spatie\Async\Task|callable $task
+     * @param int|null $outputLength
      *
      * @return \Spatie\Async\Process\Runnable
      */
-    public static function createProcess($task): Runnable
+    public static function createProcess($task, $outputLength = null): Runnable
     {
         if (! self::$isInitialised) {
             self::init();
@@ -68,6 +69,7 @@ class ParentRuntime
             self::$childProcessScript,
             self::$autoloader,
             self::encodeTask($task),
+            $outputLength
         ]);
 
         return ParallelProcess::create($process, self::getId());

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -54,7 +54,7 @@ class ParentRuntime
      *
      * @return \Spatie\Async\Process\Runnable
      */
-    public static function createProcess($task, $outputLength = null): Runnable
+    public static function createProcess($task, ?int $outputLength = null): Runnable
     {
         if (! self::$isInitialised) {
             self::init();

--- a/tests/ContentLengthTest.php
+++ b/tests/ContentLengthTest.php
@@ -41,7 +41,7 @@ class ContentLengthTest extends TestCase
     }
 
     /** @test */
-    public function it_can_throws_error_with_increased_max_content_length()
+    public function it_can_throw_error_with_increased_max_content_length()
     {
         $pool = Pool::create();
 
@@ -59,7 +59,7 @@ class ContentLengthTest extends TestCase
     }
 
     /** @test */
-    public function it_can_throws_error_with_decreased_max_content_length()
+    public function it_can_throw_error_with_decreased_max_content_length()
     {
         $pool = Pool::create();
 

--- a/tests/ContentLengthTest.php
+++ b/tests/ContentLengthTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Spatie\Async\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Async\Output\ParallelError;
+use Spatie\Async\Pool;
+
+class ContentLengthTest extends TestCase
+{
+
+    /** @test */
+    public function it_can_increase_max_content_length()
+    {
+        $pool = Pool::create();
+
+        $longerContentLength = 1024 * 100;
+
+        $pool->add(new MyTask(), $longerContentLength);
+
+        $this->assertContains('finished: 0', (string)$pool->status());
+
+        await($pool);
+
+        $this->assertContains('finished: 1', (string)$pool->status());
+    }
+
+    /** @test */
+    public function it_can_decrease_max_content_length()
+    {
+        $pool = Pool::create();
+
+        $shorterContentLength = 1024;
+
+        $pool->add(new MyTask(), $shorterContentLength);
+
+        $this->assertContains('finished: 0', (string)$pool->status());
+
+        await($pool);
+
+        $this->assertContains('finished: 1', (string)$pool->status());
+    }
+    
+    /** @test */
+    public function it_can_throws_error_with_increased_max_content_length()
+    {
+        $pool = Pool::create();
+
+        $longerContentLength = 1024 * 100;
+
+        $pool->add(function () { return random_bytes(1024 * 1000); }, $longerContentLength)
+            ->catch(function (ParallelError $e) use ($longerContentLength) {
+                $message = "/The output returned by this child process is too large. The serialized output may only be $longerContentLength bytes long./";
+                $this->assertRegExp($message, $e->getMessage());
+            });
+
+        await($pool);
+    }
+
+    /** @test */
+    public function it_can_throws_error_with_decreased_max_content_length()
+    {
+        $pool = Pool::create();
+
+        $longerContentLength = 1024;
+
+        $pool->add(function () { return random_bytes(1024 * 100); }, $longerContentLength)
+            ->catch(function (ParallelError $e) use ($longerContentLength) {
+                $message = "/The output returned by this child process is too large. The serialized output may only be $longerContentLength bytes long./";
+                $this->assertRegExp($message, $e->getMessage());
+            });
+
+        await($pool);
+    }
+}

--- a/tests/ContentLengthTest.php
+++ b/tests/ContentLengthTest.php
@@ -2,13 +2,12 @@
 
 namespace Spatie\Async\Tests;
 
+use Spatie\Async\Pool;
 use PHPUnit\Framework\TestCase;
 use Spatie\Async\Output\ParallelError;
-use Spatie\Async\Pool;
 
 class ContentLengthTest extends TestCase
 {
-
     /** @test */
     public function it_can_increase_max_content_length()
     {
@@ -18,11 +17,11 @@ class ContentLengthTest extends TestCase
 
         $pool->add(new MyTask(), $longerContentLength);
 
-        $this->assertContains('finished: 0', (string)$pool->status());
+        $this->assertContains('finished: 0', (string) $pool->status());
 
         await($pool);
 
-        $this->assertContains('finished: 1', (string)$pool->status());
+        $this->assertContains('finished: 1', (string) $pool->status());
     }
 
     /** @test */
@@ -34,13 +33,13 @@ class ContentLengthTest extends TestCase
 
         $pool->add(new MyTask(), $shorterContentLength);
 
-        $this->assertContains('finished: 0', (string)$pool->status());
+        $this->assertContains('finished: 0', (string) $pool->status());
 
         await($pool);
 
-        $this->assertContains('finished: 1', (string)$pool->status());
+        $this->assertContains('finished: 1', (string) $pool->status());
     }
-    
+
     /** @test */
     public function it_can_throws_error_with_increased_max_content_length()
     {
@@ -48,7 +47,9 @@ class ContentLengthTest extends TestCase
 
         $longerContentLength = 1024 * 100;
 
-        $pool->add(function () { return random_bytes(1024 * 1000); }, $longerContentLength)
+        $pool->add(function () {
+            return random_bytes(1024 * 1000);
+        }, $longerContentLength)
             ->catch(function (ParallelError $e) use ($longerContentLength) {
                 $message = "/The output returned by this child process is too large. The serialized output may only be $longerContentLength bytes long./";
                 $this->assertRegExp($message, $e->getMessage());
@@ -64,7 +65,9 @@ class ContentLengthTest extends TestCase
 
         $longerContentLength = 1024;
 
-        $pool->add(function () { return random_bytes(1024 * 100); }, $longerContentLength)
+        $pool->add(function () {
+            return random_bytes(1024 * 100);
+        }, $longerContentLength)
             ->catch(function (ParallelError $e) use ($longerContentLength) {
                 $message = "/The output returned by this child process is too large. The serialized output may only be $longerContentLength bytes long./";
                 $this->assertRegExp($message, $e->getMessage());


### PR DESCRIPTION
The current default limit for responses from process tasks is 1mb?

This PR will allow the user to define their own max length if needed, when adding a task to the queue.

It fixes https://github.com/spatie/async/issues/76

I tried to do some research based on @brendt's comments about large streams of data being returned being bad, but could not find anything definitive on an actual max size that restricts `STDOUT`. Would be good to hear some more info on that particular concern.