### PR TITLE
Adds new pool configuration for the path to the PHP executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 composer.lock
 vendor
-.idea

--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ $pool = Pool::create()
     
 // Configure how long the loop should sleep before re-checking the process statuses in milliseconds.
     ->sleepTime(50000)
+
+// The path to PHP executable for child runtime
+    ->executable('/opt/some/path/version-7.3/bin/php')
 ;
 ```
 

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -90,6 +90,17 @@ class Pool implements ArrayAccess
         return $this;
     }
 
+    /**
+     * @param string $executable
+     * @return $this
+     */
+    public function executable(string $executable): self
+    {
+        ParentRuntime::setExecutable($executable);
+
+        return $this;
+    }
+
     public function notify()
     {
         if (count($this->inProgress) >= $this->concurrency) {

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -27,6 +27,9 @@ class ParentRuntime
 
     protected static $myPid = null;
 
+    /** @var string */
+    protected static $executable = 'php';
+
     public static function init(string $autoloader = null)
     {
         if (! $autoloader) {
@@ -65,7 +68,7 @@ class ParentRuntime
         }
 
         $process = new Process([
-            'php',
+            self::$executable,
             self::$childProcessScript,
             self::$autoloader,
             self::encodeTask($task),
@@ -103,5 +106,13 @@ class ParentRuntime
         self::$currentId += 1;
 
         return (string) self::$currentId.(string) self::$myPid;
+    }
+
+    /**
+     * @param string $executable
+     */
+    public static function setExecutable(string $executable): void
+    {
+        self::$executable = $executable;
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -98,9 +98,9 @@ class PoolTest extends TestCase
         $notFoundError = null;
         $result = null;
 
+        // test with custom executable
         $pool = Pool::create()
                     ->executable($executable);
-
         $pool->add(function () {
             return true;
         })->then(function ($_result) use (&$result) {
@@ -109,14 +109,30 @@ class PoolTest extends TestCase
             $result = false;
             $notFoundError = $error->getMessage();
         });
-
         $pool->wait();
-
         $this->assertEquals(false, $result);
         $this->assertRegExp("%{$executable}%", $notFoundError);
 
-        // avoids errors in further tests
-        ParentRuntime::setExecutable('php');
+        // test with default executable (reset for further tests)
+        $pool = Pool::create()
+                    ->executable('php');
+        $pool->add(function () {
+            return 'reset';
+        })->then(function ($_result) use (&$result) {
+            $result = $_result;
+        });
+        $pool->wait();
+        $this->assertEquals('reset', $result);
+
+        // test with default executable
+        $pool = Pool::create();
+        $pool->add(function () {
+            return 'default';
+        })->then(function ($_result) use (&$result) {
+            $result = $_result;
+        });
+        $pool->wait();
+        $this->assertEquals('default', $result);
     }
 
     /** @test */

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -102,9 +102,9 @@ class PoolTest extends TestCase
                     ->executable($executable);
 
         $pool->add(function () {
-            sleep(1);
-        })->then(function () use (&$result) {
-            $result = true;
+            return true;
+        })->then(function ($_result) use (&$result) {
+            $result = $_result;
         })->catch(function ($error) use (&$result, &$notFoundError) {
             $result = false;
             $notFoundError = $error->getMessage();


### PR DESCRIPTION
In a separate project different PHP versions exist on one server. 

If different PHP versions exist on the server, it is now possible to specify the PHP version for the subprocesses.

Without this new option, the subprocesses use the PHP version of the standard executable php.

Usage

```php
use Spatie\Async\Pool;

$pool = Pool::create()

// ...

// The path to PHP executable for child runtime
    ->executable('/opt/some/path/version-7.3/bin/php')
;
```

