### PR TITLE
Correction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ $pool = Pool::create()
 // Configure which autoloader sub processes should use.
     ->autoload(__DIR__ . '/../../vendor/autoload.php')
     
-// Configure how long the loop should sleep before re-checking the process statuses in milliseconds.
+// Configure how long the loop should sleep before re-checking the process statuses in microseconds.
     ->sleepTime(50000)
 ;
 ```


### PR DESCRIPTION
Time unit correction - the underlying function is usleep which takes microseconds.