### PR TITLE
Turn off coverage generation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,8 +22,5 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
Unused by the CI. If people want it when they run the tests locally, they can just pass the relevant CLI args to PHPUnit.