### PR TITLE
Add ability to stop a pool early

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,14 @@ use Spatie\Async\Pool;
 
 $pool = Pool::create();
 
-// Generate 10k processes
-for ($i = 0; $i < 10000; $i++) {
-    $pool->add(function () use ($pool) {
+// Generate 10k processes generating random numbers
+for($i = 0; $i < 10000; $i++) {
+    $pool->add(function() use ($i) {
+        return rand(0, 100);
+
+    })->then(function($output) use ($pool) {
         // If one of them randomly picks 100, end the pool early.
-        if (rand(0, 100) === 100) {
+        if ($output === 100) {
             $pool->stop();
         }
     });

--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ $pool
 
 ### Stopping a pool
 
-If you need to stop a pool, because thte task it was performing is complete, you can use the
-`$pool->stop()` method. This will prevent the pool from starting any additional processes.
+If you need to stop a pool early, because the task it was performing has been completed by one
+of the child processes, you can use the `$pool->stop()` method. This will prevent the 
+pool from starting any additional processes.
 
 ```php
 use Spatie\Async\Pool;

--- a/README.md
+++ b/README.md
@@ -134,6 +134,32 @@ $pool
     });
 ```
 
+### Stopping a pool
+
+If you need to stop a pool, because thte task it was performing is complete, you can use the
+`$pool->stop()` method. This will prevent the pool from starting any additional processes.
+
+```php
+use Spatie\Async\Pool;
+
+$pool = Pool::create();
+
+// Generate 10k processes
+for ($i = 0; $i < 10000; $i++) {
+    $pool->add(function () use ($pool) {
+        // If one of them randomly picks 100, end the pool early.
+        if (rand(0, 100) === 100) {
+            $pool->stop();
+        }
+    });
+}
+
+$pool->wait();
+```
+
+Note that a pool will be rendered useless after being stopped, and a new pool should be
+created if needed.
+
 ### Working with tasks
 
 Besides using closures, you can also work with a `Task`. 

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,7 +4,6 @@ namespace Spatie\Async;
 
 use ArrayAccess;
 use InvalidArgumentException;
-use Spatie\Async\Output\ParallelError;
 use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;
 use Spatie\Async\Process\SynchronousProcess;

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,6 +4,7 @@ namespace Spatie\Async;
 
 use ArrayAccess;
 use InvalidArgumentException;
+use Spatie\Async\Output\ParallelError;
 use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;
 use Spatie\Async\Process\SynchronousProcess;
@@ -36,6 +37,8 @@ class Pool implements ArrayAccess
     protected $results = [];
 
     protected $status;
+
+    protected $stopped = false;
 
     public function __construct()
     {
@@ -162,6 +165,10 @@ class Pool implements ArrayAccess
 
     public function putInProgress(Runnable $process)
     {
+        if ($this->stopped) {
+            return;
+        }
+
         if ($process instanceof ParallelProcess) {
             $process->getProcess()->setTimeout($this->timeout);
         }
@@ -300,5 +307,10 @@ class Pool implements ArrayAccess
                 $this->markAsFailed($process);
             }
         });
+    }
+
+    public function stop()
+    {
+        $this->stopped = true;
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -288,4 +288,30 @@ class PoolTest extends TestCase
 
         $this->assertTrue($isIntermediateCallbackCalled);
     }
+
+    /** @test */
+    public function it_can_be_stopped_early()
+    {
+        $pool = Pool::create();
+
+        $maxProcesses = 10000;
+        $completedProcessesCount = 0;
+
+        for($i = 0; $i < $maxProcesses; $i++) {
+            $pool->add(function() use ($i) {
+                return rand(0, 100);
+
+            })->then(function($output) use ($pool, &$completedProcessesCount) {
+                $completedProcessesCount++;
+
+                if ($output === 100) {
+                    $pool->stop();
+                }
+            });
+        }
+
+        $pool->wait();
+
+        $this->assertLessThan($maxProcesses, $completedProcessesCount);
+    }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -297,11 +297,10 @@ class PoolTest extends TestCase
         $maxProcesses = 10000;
         $completedProcessesCount = 0;
 
-        for($i = 0; $i < $maxProcesses; $i++) {
-            $pool->add(function() use ($i) {
+        for ($i = 0; $i < $maxProcesses; $i++) {
+            $pool->add(function () use ($i) {
                 return rand(0, 100);
-
-            })->then(function($output) use ($pool, &$completedProcessesCount) {
+            })->then(function ($output) use ($pool, &$completedProcessesCount) {
                 $completedProcessesCount++;
 
                 if ($output === 100) {


### PR DESCRIPTION
This PR provides the ability to stop a pool early via a `$pool->stop()` method. This is useful if a child processes completes a task that would make running the remaining processes unnecessary.