### PR TITLE
Add support for up to microsecond timeouts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ $pool = Pool::create()
 // The maximum amount of processes which can run simultaneously.
     ->concurrency(20)
 
-// The maximum amount of time a process may take to finish in seconds.
+// The maximum amount of time a process may take to finish in seconds
+// (decimal places are supported for more granular timeouts).
     ->timeout(15)
 
 // Configure which autoloader sub processes should use.

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -71,7 +71,7 @@ class Pool implements ArrayAccess
         return $this;
     }
 
-    public function timeout(int $timeout): self
+    public function timeout(float $timeout): self
     {
         $this->timeout = $timeout;
 

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -91,6 +91,27 @@ class PoolTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_millisecond_timeouts()
+    {
+        $pool = Pool::create()
+            ->timeout(0.2);
+
+        $counter = 0;
+
+        foreach (range(1, 5) as $i) {
+            $pool->add(function () {
+                usleep(500000);
+            })->timeout(function () use (&$counter) {
+                $counter += 1;
+            });
+        }
+
+        $pool->wait();
+
+        $this->assertEquals(5, $counter, (string) $pool->status());
+    }
+
+    /** @test */
     public function it_can_handle_a_maximum_of_concurrent_processes()
     {
         $pool = Pool::create()


### PR DESCRIPTION
We've got a need to specify millisecond timeout for certain pools. Fortunately, it appears the code already supports this since it's checking execution time using `microtime(true)`.

This PR just changes the typehint on the `timeout()` function and adds a test to confirm it works.