### PR TITLE
Use current PHP binary not the one on path

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -39,7 +39,7 @@ class Pool implements ArrayAccess
 
     protected $stopped = false;
 
-    protected $binary = 'php';
+    protected $binary = PHP_BINARY;
 
     public function __construct()
     {


### PR DESCRIPTION
If a machine has multiple PHP versions the version calling the script should be used. Not just the first one in the path 

For example using php7.3 async.php and php7.4 async.php should call a different binary for all async work.