### PR TITLE
Add fallback to SerializableException to handle "complex" exceptions

### DIFF
--- a/src/Output/ParallelException.php
+++ b/src/Output/ParallelException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Spatie\Async\Output;
+
+class ParallelException extends \Exception
+{
+    /** @var string */
+    protected $originalClass;
+
+    /** @var string */
+    protected $originalTrace;
+
+    public function __construct(string $message, string $originalClass, string $originalTrace)
+    {
+        parent::__construct($message);
+        $this->originalClass = $originalClass;
+        $this->originalTrace = $originalTrace;
+    }
+
+    /** @return string */
+    public function getOriginalClass(): string
+    {
+        return $this->originalClass;
+    }
+
+    /** @return string */
+    public function getOriginalTrace(): string
+    {
+        return $this->originalTrace;
+    }
+}

--- a/src/Output/SerializableException.php
+++ b/src/Output/SerializableException.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Async\Output;
 
-use ArgumentCountError;
 use Throwable;
 
 class SerializableException
@@ -28,8 +27,8 @@ class SerializableException
         try {
             /** @var Throwable $throwable */
             $throwable = new $this->class($this->message."\n\n".$this->trace);
-        } catch (ArgumentCountError $exception) {
-            $throwable = new \Exception($this->message."\n\n".$this->trace);
+        } catch (Throwable $exception) {
+            $throwable = new ParallelException($this->message, $this->class, $this->trace);
         }
 
         return $throwable;

--- a/src/Output/SerializableException.php
+++ b/src/Output/SerializableException.php
@@ -24,8 +24,12 @@ class SerializableException
 
     public function asThrowable(): Throwable
     {
-        /** @var Throwable $throwable */
-        $throwable = new $this->class($this->message."\n\n".$this->trace);
+        try {
+            /** @var Throwable $throwable */
+            $throwable = new $this->class($this->message."\n\n".$this->trace);
+        } catch (Throwable $exception) {
+            $throwable = new \Exception($this->message."\n\n".$this->trace);
+        }
 
         return $throwable;
     }

--- a/src/Output/SerializableException.php
+++ b/src/Output/SerializableException.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Async\Output;
 
+use ArgumentCountError;
 use Throwable;
 
 class SerializableException
@@ -27,7 +28,7 @@ class SerializableException
         try {
             /** @var Throwable $throwable */
             $throwable = new $this->class($this->message."\n\n".$this->trace);
-        } catch (Throwable $exception) {
+        } catch (ArgumentCountError $exception) {
             $throwable = new \Exception($this->message."\n\n".$this->trace);
         }
 

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -7,6 +7,7 @@ use Exception;
 use ParseError;
 use PHPUnit\Framework\TestCase;
 use Spatie\Async\Output\ParallelError;
+use Spatie\Async\Output\ParallelException;
 use Spatie\Async\Pool;
 
 class ErrorHandlingTest extends TestCase
@@ -34,17 +35,40 @@ class ErrorHandlingTest extends TestCase
     {
         $pool = Pool::create();
 
-        foreach (range(1, 5) as $i) {
-            $pool->add(function () {
-                throw new MyComplexException('test', (object) ['error' => 'wrong query']);
-            })->catch(function (MyComplexException $e) {
-                $this->assertRegExp('/test/', $e->getMessage());
+        $originalExceptionCount = 0;
+        $fallbackExceptionCount = 0;
+
+        $pool
+            ->add(function () {
+                throw new MyExceptionWithAComplexArgument('test', (object) ['error' => 'wrong query']);
+            })
+            ->catch(function (MyExceptionWithAComplexArgument $e) use (&$originalExceptionCount) {
+                $originalExceptionCount += 1;
+            })
+            ->catch(function (ParallelException $e) use (&$fallbackExceptionCount) {
+                $fallbackExceptionCount += 1;
+                $this->assertEquals('test', $e->getMessage());
+                $this->assertEquals(MyExceptionWithAComplexArgument::class, $e->getOriginalClass());
             });
-        }
+
+        $pool
+            ->add(function () use (&$originalExceptionCount) {
+                throw new MyExceptionWithAComplexFirstArgument((object) ['error' => 'wrong query'], 'test');
+            })
+            ->catch(function (MyExceptionWithAComplexFirstArgument $e) use (&$originalExceptionCount) {
+                $originalExceptionCount += 1;
+            })
+            ->catch(function (ParallelException $e) use (&$fallbackExceptionCount) {
+                $fallbackExceptionCount += 1;
+                $this->assertEquals('test', $e->getMessage());
+                $this->assertEquals(MyExceptionWithAComplexFirstArgument::class, $e->getOriginalClass());
+            });
 
         $pool->wait();
 
-        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
+        $this->assertCount(2, $pool->getFailed(), (string) $pool->status());
+        $this->assertEquals(0, $originalExceptionCount);
+        $this->assertEquals(2, $fallbackExceptionCount);
     }
 
     /** @test */

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -30,6 +30,24 @@ class ErrorHandlingTest extends TestCase
     }
 
     /** @test */
+    public function it_can_handle_complex_exceptions_via_catch_callback()
+    {
+        $pool = Pool::create();
+
+        foreach (range(1, 5) as $i) {
+            $pool->add(function () {
+                throw new MyComplexException('test', (object) ['error' => 'wrong query']);
+            })->catch(function (MyComplexException $e) {
+                $this->assertRegExp('/test/', $e->getMessage());
+            });
+        }
+
+        $pool->wait();
+
+        $this->assertCount(5, $pool->getFailed(), (string) $pool->status());
+    }
+
+    /** @test */
     public function it_can_handle_typed_exceptions_via_catch_callback()
     {
         $pool = Pool::create();

--- a/tests/MyComplexException.php
+++ b/tests/MyComplexException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Async\Tests;
+
+use Exception;
+use stdClass;
+
+class MyComplexException extends Exception
+{
+    public $payload;
+
+    public function __construct(string $message, stdClass $payload)
+    {
+        parent::__construct($message);
+        $this->payload = $payload;
+    }
+}

--- a/tests/MyExceptionWithAComplexArgument.php
+++ b/tests/MyExceptionWithAComplexArgument.php
@@ -5,7 +5,7 @@ namespace Spatie\Async\Tests;
 use Exception;
 use stdClass;
 
-class MyComplexException extends Exception
+class MyExceptionWithAComplexArgument extends Exception
 {
     public $payload;
 

--- a/tests/MyExceptionWithAComplexFirstArgument.php
+++ b/tests/MyExceptionWithAComplexFirstArgument.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\Async\Tests;
+
+use Exception;
+use stdClass;
+
+class MyExceptionWithAComplexFirstArgument extends Exception
+{
+    public $payload;
+
+    public function __construct(stdClass $payload, string $message)
+    {
+        parent::__construct($message);
+        $this->payload = $payload;
+    }
+}


### PR DESCRIPTION
This package is great, but it has one major limitation. Not being able to properly serialize exceptions.

Whenever a "complex" exception is thrown, the process fatals out with a message similar to this one:

```
Too few arguments to function Illuminate\Database\QueryException::__construct(), 1 passed in /var/www/html/vendor/spatie/async/src/Output/SerializableException.php on line 28 and exactly 3 expected
```

We can catch this ArgumentCountError and gracefully handle the failure, but we have no access to the message or trace of the initial exception. We are totally in the dark and have no clue what went wrong.

This PR adds a fallback to the SerializableException to handle these kinds of situations where a "complex" exception can not be instantiated.

Instead of throwing an ArgumentCountError, a basic PHP Exception is thrown containing the message and trace of the initial exception.

With this solution, we still have to catch the Exception to gracefully handle the failure, but we at least now have access to the message and trace of the initial exception.

```php
try {
    /** @var Throwable $throwable */
    $throwable = new $this->class($this->message."\n\n".$this->trace);
} catch (ArgumentCountError $exception) {
    $throwable = new \Exception($this->message."\n\n".$this->trace);
}
```