### PR TITLE
Bump 'phpunit' version And Fix build Travis-CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.phpunit.result.cache
 build
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "larapack/dd": "^1.1",
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
         "symfony/stopwatch": "^4.0 || ^5.0"
     },
     "suggest": {

--- a/tests/ChildRuntimeTest.php
+++ b/tests/ChildRuntimeTest.php
@@ -4,7 +4,6 @@ namespace Spatie\Async\Tests;
 
 use Opis\Closure\SerializableClosure;
 use function Opis\Closure\serialize;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\Process;
 
 class ChildRuntimeTest extends TestCase
@@ -31,6 +30,6 @@ class ChildRuntimeTest extends TestCase
 
         $process->wait();
 
-        $this->assertContains('child', $process->getOutput());
+        $this->assertStringContainsString('child', $process->getOutput());
     }
 }

--- a/tests/ContentLengthTest.php
+++ b/tests/ContentLengthTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Async\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Spatie\Async\Output\ParallelError;
 use Spatie\Async\Pool;
 
@@ -17,11 +16,11 @@ class ContentLengthTest extends TestCase
 
         $pool->add(new MyTask(), $longerContentLength);
 
-        $this->assertContains('finished: 0', (string) $pool->status());
+        $this->assertStringContainsString('finished: 0', (string) $pool->status());
 
         await($pool);
 
-        $this->assertContains('finished: 1', (string) $pool->status());
+        $this->assertStringContainsString('finished: 1', (string) $pool->status());
     }
 
     /** @test */
@@ -33,11 +32,11 @@ class ContentLengthTest extends TestCase
 
         $pool->add(new MyTask(), $shorterContentLength);
 
-        $this->assertContains('finished: 0', (string) $pool->status());
+        $this->assertStringContainsString('finished: 0', (string) $pool->status());
 
         await($pool);
 
-        $this->assertContains('finished: 1', (string) $pool->status());
+        $this->assertStringContainsString('finished: 1', (string) $pool->status());
     }
 
     /** @test */
@@ -52,7 +51,7 @@ class ContentLengthTest extends TestCase
         }, $longerContentLength)
             ->catch(function (ParallelError $e) use ($longerContentLength) {
                 $message = "/The output returned by this child process is too large. The serialized output may only be $longerContentLength bytes long./";
-                $this->assertRegExp($message, $e->getMessage());
+                $this->assertMatchesRegExp($message, $e->getMessage());
             });
 
         await($pool);
@@ -70,7 +69,7 @@ class ContentLengthTest extends TestCase
         }, $longerContentLength)
             ->catch(function (ParallelError $e) use ($longerContentLength) {
                 $message = "/The output returned by this child process is too large. The serialized output may only be $longerContentLength bytes long./";
-                $this->assertRegExp($message, $e->getMessage());
+                $this->assertMatchesRegExp($message, $e->getMessage());
             });
 
         await($pool);

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -5,7 +5,6 @@ namespace Spatie\Async\Tests;
 use Error;
 use Exception;
 use ParseError;
-use PHPUnit\Framework\TestCase;
 use Spatie\Async\Output\ParallelError;
 use Spatie\Async\Output\ParallelException;
 use Spatie\Async\Pool;
@@ -21,7 +20,7 @@ class ErrorHandlingTest extends TestCase
             $pool->add(function () {
                 throw new MyException('test');
             })->catch(function (MyException $e) {
-                $this->assertRegExp('/test/', $e->getMessage());
+                $this->assertMatchesRegExp('/test/', $e->getMessage());
             });
         }
 
@@ -88,7 +87,7 @@ class ErrorHandlingTest extends TestCase
                     throw new MyException('test');
                 })
                 ->catch(function (MyException $e) use (&$myExceptionCount) {
-                    $this->assertRegExp('/test/', $e->getMessage());
+                    $this->assertMatchesRegExp('/test/', $e->getMessage());
 
                     $myExceptionCount += 1;
                 })
@@ -112,7 +111,7 @@ class ErrorHandlingTest extends TestCase
     public function it_throws_the_exception_if_no_catch_callback()
     {
         $this->expectException(MyException::class);
-        $this->expectExceptionMessageRegExp('/test/');
+        $this->expectExceptionMessageRegularExpression('/test/');
 
         $pool = Pool::create();
 
@@ -127,7 +126,7 @@ class ErrorHandlingTest extends TestCase
     public function it_throws_fatal_errors()
     {
         $this->expectException(Error::class);
-        $this->expectExceptionMessageRegExp('/test/');
+        $this->expectExceptionMessageRegularExpression('/test/');
 
         $pool = Pool::create();
 
@@ -148,7 +147,7 @@ class ErrorHandlingTest extends TestCase
 
             $myClass->throwException();
         })->catch(function (MyException $exception) {
-            $this->assertContains('Spatie\Async\Tests\MyClass->throwException()', $exception->getMessage());
+            $this->assertStringContainsString('Spatie\Async\Tests\MyClass->throwException()', $exception->getMessage());
         });
 
         $pool->wait();
@@ -162,7 +161,7 @@ class ErrorHandlingTest extends TestCase
         $pool->add(function () {
             fwrite(STDERR, 'test');
         })->catch(function (ParallelError $error) {
-            $this->assertContains('test', $error->getMessage());
+            $this->assertStringContainsString('test', $error->getMessage());
         });
 
         $pool->wait();
@@ -192,7 +191,7 @@ class ErrorHandlingTest extends TestCase
         $pool->add(function () {
             throw new MyException('test');
         })->catch(function (MyException $e) {
-            $this->assertRegExp('/test/', $e->getMessage());
+            $this->assertMatchesRegExp('/test/', $e->getMessage());
         });
 
         $pool->wait();

--- a/tests/PoolStatusTest.php
+++ b/tests/PoolStatusTest.php
@@ -5,7 +5,6 @@ namespace Spatie\Async\Tests;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Spatie\Async\Pool;
-use Spatie\Async\Tests\MyTask;
 
 class PoolStatusTest extends TestCase
 {

--- a/tests/PoolStatusTest.php
+++ b/tests/PoolStatusTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace Spatie\Async;
+namespace Spatie\Async\Tests;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Spatie\Async\Pool;
 use Spatie\Async\Tests\MyTask;
 
 class PoolStatusTest extends TestCase
@@ -15,11 +16,11 @@ class PoolStatusTest extends TestCase
 
         $pool->add(new MyTask());
 
-        $this->assertContains('finished: 0', (string) $pool->status());
+        $this->assertStringContainsString('finished: 0', (string) $pool->status());
 
         await($pool);
 
-        $this->assertContains('finished: 1', (string) $pool->status());
+        $this->assertStringContainsString('finished: 1', (string) $pool->status());
     }
 
     /** @test */
@@ -37,9 +38,9 @@ class PoolStatusTest extends TestCase
 
         $pool->wait();
 
-        $this->assertContains('finished: 0', (string) $pool->status());
-        $this->assertContains('failed: 5', (string) $pool->status());
-        $this->assertContains('failed with Exception: Test', (string) $pool->status());
+        $this->assertStringContainsString('finished: 0', (string) $pool->status());
+        $this->assertStringContainsString('failed: 5', (string) $pool->status());
+        $this->assertStringContainsString('failed with Exception: Test', (string) $pool->status());
     }
 
     /** @test */
@@ -55,6 +56,6 @@ class PoolStatusTest extends TestCase
 
         $pool->wait();
 
-        $this->assertContains('timeout: 5', (string) $pool->status());
+        $this->assertStringContainsString('timeout: 5', (string) $pool->status());
     }
 }

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Spatie\Async;
+namespace Spatie\Async\Tests;
 
 use InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use Spatie\Async\Pool;
 use Spatie\Async\Process\SynchronousProcess;
 use Spatie\Async\Tests\InvokableClass;
 use Spatie\Async\Tests\MyClass;
@@ -16,7 +16,7 @@ class PoolTest extends TestCase
     /** @var \Symfony\Component\Stopwatch\Stopwatch */
     protected $stopwatch;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/PoolTest.php
+++ b/tests/PoolTest.php
@@ -5,10 +5,6 @@ namespace Spatie\Async\Tests;
 use InvalidArgumentException;
 use Spatie\Async\Pool;
 use Spatie\Async\Process\SynchronousProcess;
-use Spatie\Async\Tests\InvokableClass;
-use Spatie\Async\Tests\MyClass;
-use Spatie\Async\Tests\MyTask;
-use Spatie\Async\Tests\NonInvokableClass;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 class PoolTest extends TestCase

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Async\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    public function expectExceptionMessageRegularExpression(string $regularExpression): void
+    {
+        if (method_exists($this, 'expectExceptionMessageMatches')) {
+            // PHPUnit 8.0+
+            $this->expectExceptionMessageMatches($regularExpression);
+        } else {
+            // legacy PHPUnit 7.5
+            $this->expectExceptionMessageRegExp($regularExpression);
+        }
+    }
+
+    public function assertMatchesRegExp($pattern, $string)
+    {
+        if (method_exists($this, 'assertMatchesRegularExpression')) {
+            // PHPUnit 10+
+            $this->assertMatchesRegularExpression($pattern, $string);
+        } else {
+            // PHPUnit < 9.2
+            $this->assertRegExp($pattern, $string);
+        }
+    }
+}


### PR DESCRIPTION
This **PR** will:

- Bump 'phpunit/phpunit' version _(easy upgrade to future versions)_
- Refactor obsolete methods
- Fix tests namespace
- Fix build **travis-ci**
- Ignore '.phpunit.result.cache' file

## Motivation

- [PHPUnit 6 is no longer supported](https://phpunit.de/supported-versions.html)
- [Travis-CI build failing](https://travis-ci.org/github/spatie/async/builds/728265497)