### PR TITLE
Check for proc_open

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -63,6 +63,7 @@ class Pool implements ArrayAccess
         return
             function_exists('pcntl_async_signals')
             && function_exists('posix_kill')
+            && function_exists('proc_open')
             && ! self::$forceSynchronous;
     }
 


### PR DESCRIPTION
Resolves the following PHP error:

>PHP Fatal error:  Uncaught Symfony\Component\Process\Exception\LogicException: The Process class relies on proc_open, which is not available on your PHP installation.