### PR TITLE
Avoid function look-ups

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -62,9 +62,9 @@ class Pool implements ArrayAccess
     {
         return
             ! self::$forceSynchronous
-            && function_exists('proc_open')
             && function_exists('pcntl_async_signals')
-            && function_exists('posix_kill');
+            && function_exists('posix_kill')
+            && function_exists('proc_open');
     }
 
     public function forceSynchronous(): self

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -62,9 +62,9 @@ class Pool implements ArrayAccess
     {
         return
             ! self::$forceSynchronous
+            && function_exists('proc_open')
             && function_exists('pcntl_async_signals')
-            && function_exists('posix_kill')
-            && function_exists('proc_open');
+            && function_exists('posix_kill');
     }
 
     public function forceSynchronous(): self

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -61,10 +61,10 @@ class Pool implements ArrayAccess
     public static function isSupported(): bool
     {
         return
-            function_exists('pcntl_async_signals')
+            ! self::$forceSynchronous
+            && function_exists('pcntl_async_signals')
             && function_exists('posix_kill')
-            && function_exists('proc_open')
-            && ! self::$forceSynchronous;
+            && function_exists('proc_open');
     }
 
     public function forceSynchronous(): self


### PR DESCRIPTION
Avoid extra function look-ups if the user disables threading. There are a few advantages here:

1. speed (although minor)
2. better compatibility with PHP Snuffleupagus

Snuffleupagus will kill execution of scripts which call `function_exists()` with `proc_open` as an argument. A workaround, probably for a separate PR, is to simply do:

```
$isSupported = false;
try {
    $proc = proc_open();
    $isSupported = true;
    proc_close($proc);
} catch (Error $e) {
    // definitely not supported
}
return $isSupported;
````