### PR TITLE
Add Ability to run in a custom loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "larapack/dd": "^1.1",
-        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.0",
+        "phpunit/phpunit": "^7.5 || ^8.5.21 || ^9.0",
         "symfony/stopwatch": "^4.0 || ^5.0"
     },
     "suggest": {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -154,7 +154,7 @@ class Pool implements ArrayAccess
      *
      * @return array|void
      */
-    public function customWait(?callable $intermediateCallback = null) {
+    public function baseWait(?callable $intermediateCallback = null) {
         foreach ($this->inProgress as $process) {
             if ($process->getCurrentExecutionTime() > $this->timeout) {
                 $this->markAsTimedOut($process);

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -169,8 +169,7 @@ class Pool implements ArrayAccess
             if ($intermediateCallback) {
                 call_user_func_array($intermediateCallback, [$this]);
             }
-        }
-        if (!$this->inProgress) {
+        }else{
             return $this->results;
         }
     }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -177,7 +177,7 @@ class Pool implements ArrayAccess
 
     public function wait(?callable $intermediateCallback = null): array {
         while ($this->inProgress) {
-            $this->customWait($intermediateCallback);
+            $this->baseWait($intermediateCallback);
             usleep($this->sleepTime);
         }
 


### PR DESCRIPTION
My use case was, using ratchet-php which inside of it uses react-php, which has a loop calling `$pool->wait()` was basically blocking the loop, I noticed inside the wait function there was a sleep method for retrying, so all I needed was to be able to just use react-php's timer, so the loop won't be blocked, for that I also need the sleep time, so I added a simple function to get that as well, here's the implementation:

```php
    private function handleWait(Pool $pool) {
        Loop::get()->addTimer($pool->getSleepTime() / 1000, function () use (
            $pool
        ) {
            $pool->baseWait();
            $this->handleWait($pool);
        });
    }
```

and the result was obviously the same as before, only this time non blocking.
This can come in handy in many cases.

the main issue leading me to fix this was : https://github.com/spatie/async/issues/170