### PR TITLE
change to Serializable Closure of laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "opis/closure": "^3.4.2",
+        "laravel/serializable-closure": "^1.0",
         "symfony/process": "^3.3 || ^4.0 || ^5.0"
     },
     "require-dev": {

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -4,8 +4,6 @@ namespace Spatie\Async\Runtime;
 
 use Closure;
 use Laravel\SerializableClosure\SerializableClosure;
-use function Opis\Closure\serialize;
-use function Opis\Closure\unserialize;
 use Spatie\Async\Pool;
 use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -3,7 +3,7 @@
 namespace Spatie\Async\Runtime;
 
 use Closure;
-use Opis\Closure\SerializableClosure;
+use Laravel\SerializableClosure\SerializableClosure;
 use function Opis\Closure\serialize;
 use function Opis\Closure\unserialize;
 use Spatie\Async\Pool;


### PR DESCRIPTION
As mentioned in https://github.com/laravel/serializable-closure

>This project is a fork of the excellent opis/closure: 3.x package. At Laravel, we decided to fork this package as the upcoming version 4.x is a complete rewrite on top of the FFI extension. As Laravel is a web framework, and FFI is not enabled by default in web requests, this fork allows us to keep using the 3.x series while adding support for new PHP versions.

the version 4 will stop working, so it's better use this package which is maintained by laravel.