### PR TITLE
Make functionality more expandable

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -40,6 +40,10 @@ class Pool implements ArrayAccess
     protected $stopped = false;
 
     protected $binary = PHP_BINARY;
+    protected $autoloader = null;
+    protected $childProcessScript = null;
+
+    protected array $extraChildProcessArgs = [];
 
     public function __construct()
     {
@@ -88,6 +92,11 @@ class Pool implements ArrayAccess
         return $this;
     }
 
+    /**
+     * @param string $autoloader
+     *
+     * @return $this
+     */
     public function autoload(string $autoloader): self
     {
         ParentRuntime::init($autoloader);
@@ -105,6 +114,21 @@ class Pool implements ArrayAccess
     public function withBinary(string $binary): self
     {
         $this->binary = $binary;
+
+        return $this;
+    }
+
+    public function withAutoloader(string $autoloader): self
+    {
+        $this->autoloader = $autoloader;
+
+        return $this;
+    }
+
+    public function withChildProcessScript(string $childProcessScript, array $extraArgs = []): self
+    {
+        $this->childProcessScript = $childProcessScript;
+        $this->extraChildProcessArgs = $extraArgs;
 
         return $this;
     }
@@ -140,7 +164,10 @@ class Pool implements ArrayAccess
             $process = ParentRuntime::createProcess(
                 $process,
                 $outputLength,
-                $this->binary
+                $this->binary,
+                $this->autoloader,
+                $this->childProcessScript,
+                $this->extraChildProcessArgs
             );
         }
 

--- a/src/Runtime/ChildRuntime.php
+++ b/src/Runtime/ChildRuntime.php
@@ -5,7 +5,7 @@ use Spatie\Async\Runtime\ParentRuntime;
 try {
     $autoloader = $argv[1] ?? null;
     $serializedClosure = $argv[2] ?? null;
-    $outputLength = $argv[3] ? intval($argv[3]) : (1024 * 10);
+    $outputLength = $argv[3] ? (int) $argv[3] : ( 1024 * 10);
 
     if (! $autoloader) {
         throw new InvalidArgumentException('No autoloader provided in child process.');

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -54,7 +54,7 @@ class ParentRuntime
      *
      * @return \Spatie\Async\Process\Runnable
      */
-    public static function createProcess($task, ?int $outputLength = null, ?string $binary = 'php'): Runnable
+    public static function createProcess($task, ?int $outputLength = null, ?string $binary = 'php', ?string $autoloader = 'php', ?string $childProcessScript = 'php', array $extraChildProcessArgs): Runnable
     {
         if (! self::$isInitialised) {
             self::init();
@@ -66,10 +66,11 @@ class ParentRuntime
 
         $process = new Process([
             $binary,
-            self::$childProcessScript,
-            self::$autoloader,
+            $childProcessScript ?: self::$childProcessScript,
+            $autoloader ?: self::$autoloader,
             self::encodeTask($task),
             $outputLength,
+            ...$extraChildProcessArgs
         ]);
 
         return ParallelProcess::create($process, self::getId());


### PR DESCRIPTION
Right now, you can only use one autoloader (using `public function autoload(string $autoloader): self`), however you can use different binaries using `withBinary` method, so I a couple of extra features overriding the static properties if needed the methods are :

1. withAutoloader
2. withChildProcessScript

## 1. withAutoloader

This basically provides the possibility of a different autoloader for every pool.

```php
    public function withAutoloader(string $autoloader): self
    {
        $this->autoloader = $autoloader;

        return $this;
    }
```

it simply overrides the static autoloader if used, it is not a replacement, that's why you don't see the `@deprecated` sign on the old `autoload` method, that method is still relevant specially when using the `functional api`, but this new method can be used for other cases.

## 2. withChildProcessScript

Currently there is no way to add some extra logic to the `ChildRuntime.php` but with this new method, you can write a completely custom script, and do whatever you want with it.

```php
    public function withChildProcessScript(string $childProcessScript, array $extraArgs = []): self
    {
        $this->childProcessScript = $childProcessScript;
        $this->extraChildProcessArgs = $extraArgs;

        return $this;
    }
```
the `extraArgs` will be assigned to the custom child script, giving it `$argv[6,7,...]`.

I have read into the library, and all these changes are compatible and exactly in the same way the rest of the library is written, hope you'd like this PR.
Let me what you know.

with Regards Steve Moretz