### PR TITLE
Set return types for ArrayAccess functions

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,6 +4,7 @@ namespace Spatie\Async;
 
 use ArrayAccess;
 use InvalidArgumentException;
+use ReturnTypeWillChange;
 use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;
 use Spatie\Async\Process\SynchronousProcess;
@@ -234,24 +235,25 @@ class Pool implements ArrayAccess
         $this->failed[$process->getPid()] = $process;
     }
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         // TODO
 
         return false;
     }
 
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         // TODO
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->add($value);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         // TODO
     }

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -4,7 +4,6 @@ namespace Spatie\Async;
 
 use ArrayAccess;
 use InvalidArgumentException;
-use ReturnTypeWillChange;
 use Spatie\Async\Process\ParallelProcess;
 use Spatie\Async\Process\Runnable;
 use Spatie\Async\Process\SynchronousProcess;
@@ -242,7 +241,7 @@ class Pool implements ArrayAccess
         return false;
     }
 
-    #[ReturnTypeWillChange]
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         // TODO

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -241,8 +241,7 @@ class Pool implements ArrayAccess
         return false;
     }
 
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): Runnable
     {
         // TODO
     }


### PR DESCRIPTION
In PHP 8.1 the functions required by the `ArrayAccess` interface require a return type or they will log a deprecation warning:

```
Return type of Spatie\Async\Pool::offsetGet($offset) should either be compatible with 
ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute 
should be used to temporarily suppress the notice
```
(see https://php.watch/versions/8.1/internal-method-return-types)

I've added a return type to the `ArrayAccess` functions `offsetExists()`, `offsetSet()`, `offsetGet()` and `offsetUnset()` in the `Pool` class. Even though most of them aren't actually implemented, they still need a return type to avoid the deprecation warning. The `offsetGet()` function returns the `Runnable` type instead of the default `mixed` because that wouldn't be compatible with PHP 7.4.

Another solution would be to add the `#[ReturnTypeWillChange]` attribute, but that will probably break in PHP 9.0. The current solution is backwards compatible with PHP 7.4 and PHP 8.0, but will break for anyone that has extended the `Pool` class and overwrites the `ArrayAccess` functions without giving a proper return type. I think it's highly unlikely that anybody does that, but if you prefer, I can also just add the `#[ReturnTypeWillChange]` attribute.