### PR TITLE
Added $outputLength parameter to async method.

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -7,12 +7,12 @@ use Spatie\Async\Runtime\ParentRuntime;
 if (! function_exists('async')) {
     /**
      * @param \Spatie\Async\Task|callable $task
-     *
+     * @param int|null $outputLength
      * @return \Spatie\Async\Process\ParallelProcess
      */
-    function async($task): Runnable
+    function async($task, ?int $outputLength = null): Runnable
     {
-        return ParentRuntime::createProcess($task);
+        return ParentRuntime::createProcess($task, $outputLength);
     }
 }
 


### PR DESCRIPTION
When the Output Length is passed to the `$pool->add` method it ignores it and throws return length is too long, When ParentRuntime::createProcess is called directly with the $longerContentLength then it works perfectly , Since the async method calles the ParentRuntime::createProcess  internally I added a parameter to accept the content length in async method and passed it to ParentRuntime::createProcess .