### PR TITLE
Fix finished process handling in PHP 8.1.22/8.2.9

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -307,15 +307,16 @@ class Pool implements ArrayAccess
 
         pcntl_signal(SIGCHLD, function ($signo, $status) {
             /**
-             * PHP 8.1.22 and 8.2.9 fixed SIGCHLD handling:
+             * PHP 8.1.22 and 8.2.9 changed SIGCHLD handling:
              * https://github.com/php/php-src/pull/11509
-             * This breaks pcntl_waitpid() at the same time, so it requires special handling.
+             * This changes pcntl_waitpid() at the same time, so it requires special handling.
              *
              * It was reverted already and probably won't work in any other PHP version.
              * https://github.com/php/php-src/pull/11863
              */
             if (phpversion() === '8.1.22' || phpversion() === '8.2.9') {
                 $this->handleFinishedProcess($status['pid'], $status['status']);
+                return;
             }
 
             while (true) {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -306,6 +306,18 @@ class Pool implements ArrayAccess
         pcntl_async_signals(true);
 
         pcntl_signal(SIGCHLD, function ($signo, $status) {
+            /**
+             * PHP 8.1.22 and 8.2.9 fixed SIGCHLD handling:
+             * https://github.com/php/php-src/pull/11509
+             * This breaks pcntl_waitpid() at the same time, so it requires special handling.
+             *
+             * It was reverted already and probably won't work in any other PHP version.
+             * https://github.com/php/php-src/pull/11863
+             */
+            if (phpversion() === '8.1.22' || phpversion() === '8.2.9') {
+                $this->handleFinishedProcess($status['pid'], $status['status']);
+            }
+
             while (true) {
                 $pid = pcntl_waitpid(-1, $processState, WNOHANG | WUNTRACED);
 
@@ -313,21 +325,24 @@ class Pool implements ArrayAccess
                     break;
                 }
 
-                $process = $this->inProgress[$pid] ?? null;
-
-                if (! $process) {
-                    continue;
-                }
-
-                if ($status['status'] === 0) {
-                    $this->markAsFinished($process);
-
-                    continue;
-                }
-
-                $this->markAsFailed($process);
+                $this->handleFinishedProcess($pid, $status['status']);
             }
         });
+    }
+
+    protected function handleFinishedProcess(int $pid, int $status) {
+        $process = $this->inProgress[$pid] ?? null;
+
+        if (!$process) {
+            return;
+        }
+
+        if ($status === 0) {
+            $this->markAsFinished($process);
+            return;
+        }
+
+        $this->markAsFailed($process);
     }
 
     public function stop()

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -316,6 +316,7 @@ class Pool implements ArrayAccess
              */
             if (phpversion() === '8.1.22' || phpversion() === '8.2.9') {
                 $this->handleFinishedProcess($status['pid'], $status['status']);
+
                 return;
             }
 
@@ -331,15 +332,17 @@ class Pool implements ArrayAccess
         });
     }
 
-    protected function handleFinishedProcess(int $pid, int $status) {
+    protected function handleFinishedProcess(int $pid, int $status)
+    {
         $process = $this->inProgress[$pid] ?? null;
 
-        if (!$process) {
+        if (! $process) {
             return;
         }
 
         if ($status === 0) {
             $this->markAsFinished($process);
+
             return;
         }
 


### PR DESCRIPTION
I'm not sure if this even should be merged since it will probably be obsolete in a few weeks, but currently, this library is broken in the latest PHP versions 8.1.22 and 8.2.9 due to this change: https://github.com/php/php-src/pull/11509

From what I understand, without this change, `SIGCHILD` is received inconsistently so `pcntl_waitpid()` is used to correctly check finished child processes. With this change, `SIGCHILD` is received consistently, but  `pcntl_waitpid()` doesn't return those processes after that, maybe because they are already considered handled?

Therefore in PHP 8.1.22 and 8.2.9, the finished processes are never handled and the waiting process hangs indefinitely. Because this is BC breaking, this was already reverted in PHP and will be back to the previous behavior in future PHP versions: https://github.com/php/php-src/pull/11863

I've added special handling for only the affected PHP versions, where the `SIGCHILD` is handled immediately without `pcntl_waitpid()`. All other PHP versions should have the same behavior as before. I'm not sure if that's the best fix, but the tests pass in PHP 8.2.9. 