### PR TITLE
Added a memoryEfficient mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 tests/another-php-binary
 .php_cs.cache
 .php-cs-fixer.cache
+.idea

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -17,6 +17,7 @@ class Pool implements ArrayAccess
     protected $tasksPerProcess = 1;
     protected $timeout = 300;
     protected $sleepTime = 50000;
+    protected $memoryEfficient = false;
 
     /** @var \Spatie\Async\Process\Runnable[] */
     protected $queue = [];
@@ -79,6 +80,13 @@ class Pool implements ArrayAccess
     public function concurrency(int $concurrency): self
     {
         $this->concurrency = $concurrency;
+
+        return $this;
+    }
+
+    public function memoryEfficient(bool $bool = true): self
+    {
+        $this->memoryEfficient = $bool;
 
         return $this;
     }
@@ -220,9 +228,13 @@ class Pool implements ArrayAccess
 
         $this->notify();
 
-        $this->results[] = $process->triggerSuccess();
+        $result = $process->triggerSuccess();
 
-        $this->finished[$process->getPid()] = $process;
+        if(! $this->memoryEfficient)
+        {
+            $this->results[] = $result;
+            $this->finished[$process->getPid()] = $process;
+        }
     }
 
     public function markAsTimedOut(Runnable $process)


### PR DESCRIPTION
Added a `memoryEfficient()` mode, when `true`, it omit storing `$this->results` and `$this->finished` after processing tasks. I think this mode can be beneficial since in many case, we don't need to recheck out the result afterwards.


**Use case**
I used your package to compute a lot of calculation with large range of numbers. So big that I had to use a php generator.
After setting the pool I used `htop` to look at memory usage and it was going up and up,  until hitting memory limit (**more than 5Go !**)  After my PR, the memory usage stay stable.

**Example usage**
```php
function rangeGenerator($start, $end)
{
    for ($i = $start; $i <= $end; $i++) {
        yield $I;
    }
}

$pool = Pool::create()
    ->memoryEfficient();
    ->concurrency(32);

$find_min = null;
foreach (rangeGenerator(0, 10000000) as $seed) {
  $pool
    ->add(function () use ($seed) {
      // Calculation related to $seed

      return $result;
    })
    ->then(function ($output) use (&$find_min) {
      if (is_null($find_min) || $output < $find_min) {
        $find_min = $output;
        echo "New min : " . $find_min . "\n";
      }
    });
}
echo "Result : " . $find_min . "\n";
```

Side note: Should we throw an exception on getFinished() if memoryEfficient is set to true ?