### PR TITLE
Improve Code Quality by adding as much as possible typed properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 tests/another-php-binary
 .php_cs.cache
 .php-cs-fixer.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^7.4 || ^8.0",
         "laravel/serializable-closure": "^1.0",
         "symfony/process": "^3.3 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },

--- a/phpunit.xml.dist.legacy
+++ b/phpunit.xml.dist.legacy
@@ -1,15 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     backupGlobals="false"
+    backupStaticAttributes="false"
     colors="true"
+    verbose="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    cacheDirectory=".phpunit.cache"
-    backupStaticProperties="false"
 >
+    <coverage>
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Spatie Test Suite">
             <directory>tests</directory>
@@ -18,9 +26,4 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
-    <source>
-        <include>
-            <directory suffix=".php">src/</directory>
-        </include>
-    </source>
 </phpunit>

--- a/src/Output/ParallelException.php
+++ b/src/Output/ParallelException.php
@@ -4,11 +4,9 @@ namespace Spatie\Async\Output;
 
 class ParallelException extends \Exception
 {
-    /** @var string */
-    protected $originalClass;
+    protected string $originalClass;
 
-    /** @var string */
-    protected $originalTrace;
+    protected string $originalTrace;
 
     public function __construct(string $message, string $originalClass, string $originalTrace)
     {
@@ -17,13 +15,11 @@ class ParallelException extends \Exception
         $this->originalTrace = $originalTrace;
     }
 
-    /** @return string */
     public function getOriginalClass(): string
     {
         return $this->originalClass;
     }
 
-    /** @return string */
     public function getOriginalTrace(): string
     {
         return $this->originalTrace;

--- a/src/Output/SerializableException.php
+++ b/src/Output/SerializableException.php
@@ -6,14 +6,11 @@ use Throwable;
 
 class SerializableException
 {
-    /** @var string */
-    protected $class;
+    protected string $class;
 
-    /** @var string */
-    protected $message;
+    protected string $message;
 
-    /** @var string */
-    protected $trace;
+    protected string $trace;
 
     public function __construct(Throwable $exception)
     {

--- a/src/Pool.php
+++ b/src/Pool.php
@@ -11,37 +11,37 @@ use Spatie\Async\Runtime\ParentRuntime;
 
 class Pool implements ArrayAccess
 {
-    public static $forceSynchronous = false;
+    public static bool $forceSynchronous = false;
 
-    protected $concurrency = 20;
-    protected $tasksPerProcess = 1;
-    protected $timeout = 300;
-    protected $sleepTime = 50000;
+    protected int $concurrency = 20;
+    protected int $tasksPerProcess = 1;
+    protected float $timeout = 300;
+    protected int $sleepTime = 50000;
 
-    /** @var \Spatie\Async\Process\Runnable[] */
-    protected $queue = [];
+    /** @var Runnable[] */
+    protected array $queue = [];
 
-    /** @var \Spatie\Async\Process\Runnable[] */
-    protected $inProgress = [];
+    /** @var Runnable[] */
+    protected array $inProgress = [];
 
-    /** @var \Spatie\Async\Process\Runnable[] */
-    protected $finished = [];
+    /** @var Runnable[] */
+    protected array $finished = [];
 
-    /** @var \Spatie\Async\Process\Runnable[] */
-    protected $failed = [];
+    /** @var Runnable[] */
+    protected array $failed = [];
 
-    /** @var \Spatie\Async\Process\Runnable[] */
-    protected $timeouts = [];
+    /** @var Runnable[] */
+    protected array $timeouts = [];
 
-    protected $results = [];
+    protected array $results = [];
 
-    protected $status;
+    protected PoolStatus $status;
 
-    protected $stopped = false;
+    protected bool $stopped = false;
 
-    protected $binary = PHP_BINARY;
+    protected string $binary = PHP_BINARY;
 
-    protected $maxTaskPayloadInBytes = 100000;
+    protected int $maxTaskPayloadInBytes = 100000;
 
     public function __construct()
     {
@@ -134,10 +134,10 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @param \Spatie\Async\Process\Runnable|callable $process
+     * @param Runnable|callable $process
      * @param int|null $outputLength
      *
-     * @return \Spatie\Async\Process\Runnable
+     * @return Runnable
      */
     public function add($process, ?int $outputLength = null): Runnable
     {
@@ -271,7 +271,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\Process\Runnable[]
+     * @return Runnable[]
      */
     public function getQueue(): array
     {
@@ -279,7 +279,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\Process\Runnable[]
+     * @return Runnable[]
      */
     public function getInProgress(): array
     {
@@ -287,7 +287,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\Process\Runnable[]
+     * @return Runnable[]
      */
     public function getFinished(): array
     {
@@ -295,7 +295,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\Process\Runnable[]
+     * @return Runnable[]
      */
     public function getFailed(): array
     {
@@ -303,7 +303,7 @@ class Pool implements ArrayAccess
     }
 
     /**
-     * @return \Spatie\Async\Process\Runnable[]
+     * @return Runnable[]
      */
     public function getTimeouts(): array
     {

--- a/src/PoolStatus.php
+++ b/src/PoolStatus.php
@@ -7,7 +7,7 @@ use Spatie\Async\Process\ParallelProcess;
 
 class PoolStatus
 {
-    protected $pool;
+    protected Pool $pool;
 
     public function __construct(Pool $pool)
     {

--- a/src/Process/ParallelProcess.php
+++ b/src/Process/ParallelProcess.php
@@ -10,14 +10,15 @@ use Throwable;
 class ParallelProcess implements Runnable
 {
     use ProcessCallbacks;
-    protected $process;
-    protected $id;
-    protected $pid;
+
+    protected Process $process;
+    protected int $id;
+    protected ?int $pid;
 
     protected $output;
     protected $errorOutput;
 
-    protected $startTime;
+    protected float $startTime;
 
     public function __construct(Process $process, int $id)
     {

--- a/src/Process/ProcessCallbacks.php
+++ b/src/Process/ProcessCallbacks.php
@@ -7,9 +7,9 @@ use Throwable;
 
 trait ProcessCallbacks
 {
-    protected $successCallbacks = [];
-    protected $errorCallbacks = [];
-    protected $timeoutCallbacks = [];
+    protected array $successCallbacks = [];
+    protected array $errorCallbacks = [];
+    protected array $timeoutCallbacks = [];
 
     public function then(callable $callback): self
     {

--- a/src/Process/SynchronousProcess.php
+++ b/src/Process/SynchronousProcess.php
@@ -8,13 +8,14 @@ use Throwable;
 class SynchronousProcess implements Runnable
 {
     use ProcessCallbacks;
-    protected $id;
+
+    protected int $id;
 
     protected $task;
 
     protected $output;
     protected $errorOutput;
-    protected $executionTime;
+    protected float $executionTime;
 
     public function __construct(callable $task, int $id)
     {

--- a/src/Runtime/ParentRuntime.php
+++ b/src/Runtime/ParentRuntime.php
@@ -13,18 +13,15 @@ use Symfony\Component\Process\Process;
 
 class ParentRuntime
 {
-    /** @var bool */
-    protected static $isInitialised = false;
+    protected static bool $isInitialised = false;
 
-    /** @var string */
-    protected static $autoloader;
+    protected static string $autoloader;
 
-    /** @var string */
-    protected static $childProcessScript;
+    protected static string $childProcessScript;
 
-    protected static $currentId = 0;
+    protected static int $currentId = 0;
 
-    protected static $myPid = null;
+    protected static ?int $myPid = null;
 
     public static function init(string $autoloader = null)
     {


### PR DESCRIPTION
Hello,

As this package requires at least PHP 7.4, I think we could generalized, as much as possible, [Typed properties](https://wiki.php.net/rfc/typed_properties_v2) implementation.

This is the main goal of this PR.
Second objective : migrate PHPUnit config file to schema 10.5 and keep a `phpunit.xml.dist.legacy` for previous version v9.
Third, fix the PHP constraint on `composer.json` even if old syntax is still supported (but for how long time).

Current test results of version 1.6.1

```text
PHPUnit 10.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.15
Configuration: /shared/backups/forks/async/phpunit.xml.dist

....................................                              36 / 36 (100%)

Time: 00:14.361, Memory: 28.76 MB

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

OK, but there were issues!
Tests: 36, Assertions: 69, Deprecations: 1.
```

After PHPUnit config file migration and added typed properties

```text
PHPUnit 10.5.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.15
Configuration: /shared/backups/forks/async/phpunit.xml.dist

....................................                              36 / 36 (100%)

Time: 00:14.315, Memory: 28.76 MB

OK (36 tests, 69 assertions)
```

