### PR TITLE
Fail if `unserialize` is unable to parse output of child process

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
+    beStrictAboutTestsThatDoNotTestAnything="true"
 >
     <coverage>
         <include>

--- a/src/Process/ParallelProcess.php
+++ b/src/Process/ParallelProcess.php
@@ -68,11 +68,15 @@ class ParallelProcess implements Runnable
         if (! $this->output) {
             $processOutput = $this->process->getOutput();
 
-            $this->output = @unserialize(base64_decode($processOutput));
+			$childResult = @unserialize(base64_decode($processOutput));
 
-            if (! $this->output) {
+            if ($childResult === false || ! array_key_exists('output', $childResult)) {
                 $this->errorOutput = $processOutput;
+
+				return null;
             }
+
+			$this->output = $childResult['output'];
         }
 
         return $this->output;
@@ -83,11 +87,13 @@ class ParallelProcess implements Runnable
         if (! $this->errorOutput) {
             $processOutput = $this->process->getErrorOutput();
 
-            $this->errorOutput = @unserialize(base64_decode($processOutput));
+			$childResult = @unserialize(base64_decode($processOutput));
 
-            if (! $this->errorOutput) {
+            if ($childResult === false || ! array_key_exists('output', $childResult)) {
                 $this->errorOutput = $processOutput;
-            }
+			} else {
+				$this->errorOutput = $childResult['output'];
+			}
         }
 
         return $this->errorOutput;

--- a/src/Process/ProcessCallbacks.php
+++ b/src/Process/ProcessCallbacks.php
@@ -34,13 +34,13 @@ trait ProcessCallbacks
 
     public function triggerSuccess()
     {
+        $output = $this->getOutput();
+
         if ($this->getErrorOutput()) {
             $this->triggerError();
 
             return;
         }
-
-        $output = $this->getOutput();
 
         foreach ($this->successCallbacks as $callback) {
             call_user_func_array($callback, [$output]);

--- a/src/Runtime/ChildRuntime.php
+++ b/src/Runtime/ChildRuntime.php
@@ -2,6 +2,16 @@
 
 use Spatie\Async\Runtime\ParentRuntime;
 
+// php://stdout does not obey output buffering. Any output would break
+// unserialization of child process results in the parent process.
+if (!defined('STDOUT')) {
+    define('STDOUT', fopen('php://temp', 'w+b'));
+    define('STDERR', fopen('php://stderr', 'wb'));
+}
+
+ini_set('display_startup_errors', 1);
+ini_set('display_errors', 'stderr');
+
 try {
     $autoloader = $argv[1] ?? null;
     $serializedClosure = $argv[2] ?? null;
@@ -23,7 +33,9 @@ try {
 
     $task = ParentRuntime::decodeTask($serializedClosure);
 
+    ob_start();
     $output = call_user_func($task);
+    ob_end_clean();
 
     $serializedOutput = base64_encode(serialize(['output' => $output]));
 

--- a/src/Runtime/ChildRuntime.php
+++ b/src/Runtime/ChildRuntime.php
@@ -25,7 +25,7 @@ try {
 
     $output = call_user_func($task);
 
-    $serializedOutput = base64_encode(serialize($output));
+    $serializedOutput = base64_encode(serialize(['output' => $output]));
 
     if (strlen($serializedOutput) > $outputLength) {
         throw \Spatie\Async\Output\ParallelError::outputTooLarge($outputLength);
@@ -39,7 +39,7 @@ try {
 
     $output = new \Spatie\Async\Output\SerializableException($exception);
 
-    fwrite(STDERR, base64_encode(serialize($output)));
+    fwrite(STDERR, base64_encode(serialize(['output' => $output])));
 
     exit(1);
 }

--- a/tests/ChildRuntimeTest.php
+++ b/tests/ChildRuntimeTest.php
@@ -15,7 +15,8 @@ class ChildRuntimeTest extends TestCase
         $autoloader = __DIR__.'/../vendor/autoload.php';
 
         $serializedClosure = base64_encode(serialize(new SerializableClosure(function () {
-            echo 'child';
+            echo 'interfere with output';
+            return 'child';
         })));
 
         $process = new Process([
@@ -28,7 +29,10 @@ class ChildRuntimeTest extends TestCase
         $process->start();
 
         $process->wait();
+        $output = unserialize(base64_decode($process->getOutput()));
 
-        $this->assertStringContainsString('child', $process->getOutput());
+        $this->assertIsArray($output);
+        $this->assertArrayHasKey('output', $output);
+        $this->assertStringContainsString('child', $output['output']);
     }
 }

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -168,6 +168,22 @@ class ErrorHandlingTest extends TestCase
     }
 
     /** @test */
+    public function it_handles_stdout_as_parallel_error()
+    {
+        $pool = Pool::create();
+
+        $pool->add(function () {
+            fwrite(STDOUT, 'test');
+        })->then(function ($output) {
+            $this->fail('Child process output did not error on faulty output');
+        })->catch(function (ParallelError $error) {
+            $this->assertStringContainsString('test', $error->getMessage());
+        });
+
+        $pool->wait();
+    }
+
+    /** @test */
     public function deep_syntax_errors_are_thrown()
     {
         $pool = Pool::create();


### PR DESCRIPTION
In `ParallelProcess` in `getOutput()` is checked if the `unserialize` is successful.
When it fails, is sets the `errorOutput` to the process output.  
https://github.com/spatie/async/blob/c270e692f6eabafb4312e1ecd44e062032785635/src/Process/ParallelProcess.php#L71-L75

But this is not validated anymore because the check is already passed. 
https://github.com/spatie/async/blob/c270e692f6eabafb4312e1ecd44e062032785635/src/Process/ProcessCallbacks.php#L35-L50


Moving the `getOutput()` before the error output check will ensure all error output cases are handled properly.

Adding extra checks on the output of the child processes, we can ensure the output of the task is not false or null, falsely triggering the `errorOutput`.
By changing the `ChildRuntime` output to a predictable array ensures we can check if something is wrong with parsing the child processes output.
