### PR TITLE
Pool.php - add methods to clear finished/results cache (#235)

### DIFF
--- a/src/Pool.php
+++ b/src/Pool.php
@@ -367,4 +367,15 @@ class Pool implements ArrayAccess
     {
         $this->stopped = true;
     }
+
+    public function clearFinished()
+    {
+        $this->finished = [];
+    }
+
+    public function clearResults()
+    {
+        $this->results = [];
+    }
+
 }


### PR DESCRIPTION
Since the member variables of finished/results keep growing indefinitely over time this is a source of a memory leak. This memory leak is resolvable by clearing the result caches with the newly introduced methods.