### PR TITLE
Fix STDERR pollution corrupting exception serialization + silent exception swallowing

### DIFF
--- a/src/Process/ParallelProcess.php
+++ b/src/Process/ParallelProcess.php
@@ -87,6 +87,13 @@ class ParallelProcess implements Runnable
         if (! $this->errorOutput) {
             $processOutput = $this->process->getErrorOutput();
 
+            $marker = '___SPATIE_ASYNC_CHILD___';
+            $markerPosition = strrpos($processOutput, $marker);
+
+            if ($markerPosition !== false) {
+                $processOutput = substr($processOutput, $markerPosition + strlen($marker));
+            }
+
             $childResult = @unserialize(base64_decode($processOutput));
 
             if ($childResult === false || ! array_key_exists('output', $childResult)) {

--- a/src/Process/ProcessCallbacks.php
+++ b/src/Process/ProcessCallbacks.php
@@ -64,8 +64,10 @@ trait ProcessCallbacks
 
             call_user_func_array($callback, [$exception]);
 
-            break;
+            return;
         }
+
+        throw $exception;
     }
 
     abstract protected function resolveErrorOutput(): Throwable;

--- a/src/Runtime/ChildRuntime.php
+++ b/src/Runtime/ChildRuntime.php
@@ -51,7 +51,7 @@ try {
 
     $output = new \Spatie\Async\Output\SerializableException($exception);
 
-    fwrite(STDERR, base64_encode(serialize(['output' => $output])));
+    fwrite(STDERR, '___SPATIE_ASYNC_CHILD___'.base64_encode(serialize(['output' => $output])));
 
     exit(1);
 }

--- a/tests/Feature/ErrorHandlingTest.php
+++ b/tests/Feature/ErrorHandlingTest.php
@@ -185,6 +185,37 @@ it('throws deep syntax errors', function () {
     expect($caughtError)->toBeInstanceOf(ParseError::class);
 });
 
+it('preserves exception type when stderr contains noise', function () {
+    $pool = Pool::create();
+
+    $caughtException = null;
+
+    $pool->add(childTask(function () {
+        trigger_error('some deprecation notice', E_USER_WARNING);
+
+        throw new MyException('test');
+    }))->catch(function (MyException $e) use (&$caughtException) {
+        $caughtException = $e;
+    });
+
+    $pool->wait();
+
+    expect($caughtException)->toBeInstanceOf(MyException::class);
+    expect($caughtException->getMessage())->toContain('test');
+});
+
+it('throws exception when no catch handler matches', function () {
+    $pool = Pool::create();
+
+    $pool->add(childTask(function () {
+        throw new MyException('test');
+    }))->catch(function (OtherException $e) {
+        // This handler should not match
+    });
+
+    $pool->wait();
+})->throws(MyException::class);
+
 it('can handle synchronous exception', function () {
     Pool::$forceSynchronous = true;
 

--- a/tests/Feature/PoolTest.php
+++ b/tests/Feature/PoolTest.php
@@ -336,7 +336,9 @@ it('does memory footprint controllable by clearing results', function () {
     $cntTasks = 30;
 
     foreach (range(1, $cntTasks) as $i) {
-        $pool->add(childTask(function () { return 1; }));
+        $pool->add(childTask(function () {
+            return 1;
+        }));
     }
 
     $pool->wait();


### PR DESCRIPTION
## Summary

- **STDERR pollution fix**: When PHP emits deprecation notices/warnings to STDERR during child task execution, the serialized exception data written to the same stream gets corrupted. The parent process can't deserialize the combined output and falls back to an empty `ParallelError`. Fixed by using a `___SPATIE_ASYNC_CHILD___` delimiter marker — the child prepends it before the serialized data, and the parent uses `strrpos()` to extract only the data after it.
- **Silent exception swallowing fix**: When `catch()` handlers are registered but none match the thrown exception type, the exception was silently swallowed. Now the exception is thrown if no handler matches.

## Test plan

- [x] Added test: child emits `trigger_error()` warning then throws — verifies original exception type is preserved
- [x] Added test: only a non-matching typed catch handler is registered — verifies the exception is thrown
- [x] All existing tests pass

Fixes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)